### PR TITLE
Add option value names

### DIFF
--- a/src/core/Statiq.App/Commands/BaseCommandSettings.cs
+++ b/src/core/Statiq.App/Commands/BaseCommandSettings.cs
@@ -6,7 +6,7 @@ namespace Statiq.App
 {
     public class BaseCommandSettings : CommandSettings
     {
-        [CommandOption("-l|--log-level")]
+        [CommandOption("-l|--log-level <LEVEL>")]
         [Description("Sets the minimum log level (\"Critical\", \"Error\", \"Warning\", \"Information\", \"Debug\", \"Trace\", \"None\").")]
         public LogLevel LogLevel { get; set; } = LogLevel.Information;
 
@@ -14,12 +14,12 @@ namespace Statiq.App
         [Description("Pause execution at the start of the program until a debugger is attached.")]
         public bool Attach { get; set; }
 
-        [CommandOption("-f|--log-file")]
+        [CommandOption("-f|--log-file <LOGFILE>")]
         [Description("Log all messages to the specified log file.")]
         public string LogFile { get; set; }
 
-        [CommandOption("-s|--setting")]
-        [Description("Specifies a setting as a key=value pair (the value can be omited .")]
+        [CommandOption("-s|--setting <SETTING>")]
+        [Description("Specifies a setting as a key=value pair (the value can be omited).")]
         public string[] Settings { get; set; }
     }
 }

--- a/src/core/Statiq.App/Commands/BuildCommandSettings.cs
+++ b/src/core/Statiq.App/Commands/BuildCommandSettings.cs
@@ -10,7 +10,7 @@ namespace Statiq.App
 {
     public class BuildCommandSettings : EngineCommandSettings
     {
-        [CommandOption("-p|--pipeline")]
+        [CommandOption("-p|--pipeline <PIPELINE>")]
         [Description("Explicitly specifies one or more pipelines to execute.")]
         public string[] Pipelines { get; set; }
 

--- a/src/core/Statiq.App/Commands/EngineCommandSettings.cs
+++ b/src/core/Statiq.App/Commands/EngineCommandSettings.cs
@@ -10,11 +10,11 @@ namespace Statiq.App
 {
     public class EngineCommandSettings : BaseCommandSettings
     {
-        [CommandOption("-i|--input")]
+        [CommandOption("-i|--input <PATH>")]
         [Description("The path(s) of input files, can be absolute or relative to the current folder.")]
         public string[] InputPaths { get; set; }
 
-        [CommandOption("-o|--output")]
+        [CommandOption("-o|--output <PATH>")]
         [Description("The path to output files, can be absolute or relative to the current folder.")]
         public string OutputPath { get; set; }
 

--- a/src/core/Statiq.App/Commands/PreviewCommandSettings.cs
+++ b/src/core/Statiq.App/Commands/PreviewCommandSettings.cs
@@ -16,7 +16,7 @@ namespace Statiq.App
 {
     internal class PreviewCommandSettings : BuildCommandSettings
     {
-        [CommandOption("--port")]
+        [CommandOption("--port <PORT>")]
         [Description("Start the preview web server on the specified port (default is 5080).")]
         public int Port { get; set; } = 5080;
 
@@ -24,11 +24,11 @@ namespace Statiq.App
         [Description("Force the use of extensions in the preview web server (by default, extensionless URLs may be used).")]
         public bool ForceExt { get; set; }
 
-        [CommandOption("--virtual-dir")]
+        [CommandOption("--virtual-dir <PATH>")]
         [Description("Serve files in the preview web server under the specified virtual directory.")]
         public string VirtualDirectory { get; set; }
 
-        [CommandOption("--content-type")]
+        [CommandOption("--content-type <TYPE>")]
         [Description("Specifies additional supported content types for the preview server as extension=contenttype.")]
         public string[] ContentTypes { get; set; }
 


### PR DESCRIPTION
This commit adds option value names for all CLI options that are not booleans. Specte.Cli (the CLI library) will at some point require this, so this is as a preemptive solution to that problem.