### PR TITLE
Fix MirrorResources relative path exception on mac

### DIFF
--- a/src/extensions/Statiq.Html/MirrorResources.cs
+++ b/src/extensions/Statiq.Html/MirrorResources.cs
@@ -137,11 +137,14 @@ namespace Statiq.Html
             {
                 source = $"http:{source}";
             }
-            if (!Uri.TryCreate(source, UriKind.Absolute, out Uri uri))
+
+            Uri.TryCreate(source, UriKind.Absolute, out Uri uri);
+            if (uri is null ||
+                (uri is object && uri.Scheme != Uri.UriSchemeHttp && uri.Scheme != Uri.UriSchemeHttps))
             {
-                // Not absolute
                 return null;
             }
+
             FilePath path = _pathFunc(uri);
             if (path == null)
             {

--- a/src/extensions/Statiq.Html/MirrorResources.cs
+++ b/src/extensions/Statiq.Html/MirrorResources.cs
@@ -138,9 +138,10 @@ namespace Statiq.Html
                 source = $"http:{source}";
             }
 
-            Uri.TryCreate(source, UriKind.Absolute, out Uri uri);
-            if (uri is null ||
-                (uri is object && uri.Scheme != Uri.UriSchemeHttp && uri.Scheme != Uri.UriSchemeHttps))
+            // Make sure it's a valid HTTP or HTTPS URI
+            if (!Uri.TryCreate(source, UriKind.Absolute, out Uri uri)
+                || uri is null
+                || (uri.Scheme != Uri.UriSchemeHttp && uri.Scheme != Uri.UriSchemeHttps))
             {
                 return null;
             }

--- a/tests/extensions/Statiq.Html.Tests/MirrorResourcesFixture.cs
+++ b/tests/extensions/Statiq.Html.Tests/MirrorResourcesFixture.cs
@@ -66,6 +66,34 @@ namespace Statiq.Html.Tests
             }
 
             [Test]
+            public async Task DoesNotReplaceRelativePaths()
+            {
+                // Given
+                TestDocument document = new TestDocument(
+                    @"<html>
+                      <head>
+                        <link rel=""apple-touch-icon"" sizes=""120x120"" href=""/apple-touch-icon.png"">
+                      </head>
+                      <body>
+                      </body>
+                    </html>");
+                MirrorResources module = new MirrorResources();
+
+                // When
+                TestDocument result = await ExecuteAsync(document, module).SingleAsync();
+
+                // Then
+                result.Content.ShouldBe(
+                    @"<html>
+                      <head>
+                        <link rel=""apple-touch-icon"" sizes=""120x120"" href=""/apple-touch-icon.png"">
+                      </head>
+                      <body>
+                      </body>
+                    </html>", StringCompareShould.IgnoreLineEndings);
+            }
+
+            [Test]
             public async Task DoesNotReplaceDataNoMirrorAttribute()
             {
                 // Given


### PR DESCRIPTION
On macOS and .NET Core 3.0, a relative href is interpreted as a file://
uri and will be parsed into a Uri object successfully.  This causes the
MirrorResources module to fail when trying to create an http request
with a file:// scheme.  Only http:// and https:// schemes are valid.