### PR TITLE
Fix CacheDocuments

### DIFF
--- a/src/core/Statiq.Common/Documents/Document{TDocument}.cs
+++ b/src/core/Statiq.Common/Documents/Document{TDocument}.cs
@@ -261,7 +261,9 @@ namespace Statiq.Common
                 hash.Add(await Crc32.CalculateAsync(stream));
             }
 
-            foreach (KeyValuePair<string, object> item in this)
+            // We exclude ContentProvider from hash as we already added CRC for content above.
+            foreach (KeyValuePair<string, object> item in this
+                .Where(x => x.Key != nameof(ContentProvider)))
             {
                 hash.Add(item.Key);
                 hash.Add(item.Value);

--- a/src/core/Statiq.Common/Documents/Document{TDocument}.cs
+++ b/src/core/Statiq.Common/Documents/Document{TDocument}.cs
@@ -175,6 +175,7 @@ namespace Statiq.Common
         }
 
         /// <inheritdoc />
+        [PropertyMetadata(null)]
         public Guid Id { get; private set; } = Guid.NewGuid();
 
         protected IMetadata BaseMetadata

--- a/src/core/Statiq.Common/Documents/IDocument.Defaults.cs
+++ b/src/core/Statiq.Common/Documents/IDocument.Defaults.cs
@@ -84,7 +84,9 @@ namespace Statiq.Common
                 hash.Add(await Crc32.CalculateAsync(stream));
             }
 
-            foreach (KeyValuePair<string, object> item in this)
+            // We exclude ContentProvider from hash as we already added CRC for content above.
+            foreach (KeyValuePair<string, object> item in this
+                .Where(x => x.Key != nameof(ContentProvider)))
             {
                 hash.Add(item.Key);
                 hash.Add(item.Value);

--- a/src/core/Statiq.Core/Modules/Control/CacheDocuments.cs
+++ b/src/core/Statiq.Core/Modules/Control/CacheDocuments.cs
@@ -111,7 +111,7 @@ namespace Statiq.Core
                         }
 
                         // Miss with non-null source: track source and input documents so we can cache for next pass
-                        message = $"Cache miss for {inputsBySource.Key}, source not cached";
+                        message ??= $"Cache miss for {inputsBySource.Key}, source not cached";
                         missesBySource.Add(inputsBySource.Key, inputHash);
                     }
 

--- a/tests/core/Statiq.Common.Tests/Documents/DocumentFixture.cs
+++ b/tests/core/Statiq.Common.Tests/Documents/DocumentFixture.cs
@@ -115,7 +115,7 @@ namespace Statiq.Common.Tests.Documents
                 Document document = new Document();
 
                 // Then
-                document.Keys.ShouldBe(new[] { "Id", "Source", "Destination", "ContentProvider" }, true);
+                document.Keys.ShouldBe(new[] { "Source", "Destination", "ContentProvider" }, true);
             }
         }
 
@@ -137,7 +137,7 @@ namespace Statiq.Common.Tests.Documents
                 int count = document.Count;
 
                 // Then
-                count.ShouldBe(8);
+                count.ShouldBe(7);
             }
 
             [Test]
@@ -157,7 +157,7 @@ namespace Statiq.Common.Tests.Documents
                 int count = document.Count;
 
                 // Then
-                count.ShouldBe(8);
+                count.ShouldBe(7);
             }
         }
 

--- a/tests/core/Statiq.Core.Tests/Modules/Control/CacheDocumentsFixture.cs
+++ b/tests/core/Statiq.Core.Tests/Modules/Control/CacheDocumentsFixture.cs
@@ -1,0 +1,36 @@
+﻿using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using NUnit.Framework;
+using Statiq.Common;
+using Statiq.Testing;
+
+namespace Statiq.Core.Tests.Modules.Control
+{
+    [TestFixture]
+    public class CacheDocumentsFixture : BaseFixture
+    {
+        public class ExecuteTests : CacheDocumentsFixture
+        {
+            [Test]
+            public async Task CachesDocuments()
+            {
+                // Given
+                TestDocument a1 = new TestDocument(new FilePath("/input/a"), "a");
+                TestDocument b1 = new TestDocument(new FilePath("/input/b"), "b");
+                TestDocument a2 = new TestDocument(new FilePath("/input/a"), "aa");
+                TestDocument b2 = new TestDocument(new FilePath("/input/b"), "b");
+                CacheDocuments cacheDocuments = new CacheDocuments(
+                    new SetMetadata("Content", Config.FromDocument(async doc => await doc.GetContentStringAsync())));
+
+                // When
+                _ = await ExecuteAsync(new[] { a1, b1 }, cacheDocuments);
+                IReadOnlyList<TestDocument> results = await ExecuteAsync(new[] { a2, b2 }, cacheDocuments);
+
+                // Then
+                CollectionAssert.AreEqual(new[] { "b", "aa" }, results.Select(x => x["Content"]));
+                CollectionAssert.AreEqual(new[] { b1.Id, a2.Id }, results.Select(x => x.Id));
+            }
+        }
+    }
+}

--- a/tests/extensions/Statiq.CodeAnalysis.Tests/Scripting/ScriptHelperFixture.cs
+++ b/tests/extensions/Statiq.CodeAnalysis.Tests/Scripting/ScriptHelperFixture.cs
@@ -35,7 +35,6 @@ int x = 0;
 return null;
 }
 
-public object Id => Document.Get(""Id"");
 public object Source => Document.Get(""Source"");
 public object Destination => Document.Get(""Destination"");
 public object ContentProvider => Document.Get(""ContentProvider"");
@@ -78,7 +77,6 @@ return 0;
 return null;
 }
 
-public object Id => Document.Get(""Id"");
 public object Source => Document.Get(""Source"");
 public object Destination => Document.Get(""Destination"");
 public object ContentProvider => Document.Get(""ContentProvider"");
@@ -139,7 +137,6 @@ Pipelines.Add(Content());
 return null;
 }
 
-public object Id => Document.Get(""Id"");
 public object Source => Document.Get(""Source"");
 public object Destination => Document.Get(""Destination"");
 public object ContentProvider => Document.Get(""ContentProvider"");
@@ -215,7 +212,6 @@ public string Self(string x)
 {
     return x.ToLower();
 }
-public object Id => Document.Get(""Id"");
 public object Source => Document.Get(""Source"");
 public object Destination => Document.Get(""Destination"");
 public object ContentProvider => Document.Get(""ContentProvider"");
@@ -277,7 +273,6 @@ public string Self(string x)
 {
     return x.ToLower();
 }
-public object Id => Document.Get(""Id"");
 public object Source => Document.Get(""Source"");
 public object Destination => Document.Get(""Destination"");
 public object ContentProvider => Document.Get(""ContentProvider"");
@@ -335,7 +330,6 @@ Pipelines.Add(Content());
 return null;
 }
 
-public object Id => Document.Get(""Id"");
 public object Source => Document.Get(""Source"");
 public object Destination => Document.Get(""Destination"");
 public object ContentProvider => Document.Get(""ContentProvider"");
@@ -409,7 +403,6 @@ public string Self(string x)
     // RTY
     return x.ToLower();
 }
-public object Id => Document.Get(""Id"");
 public object Source => Document.Get(""Source"");
 public object Destination => Document.Get(""Destination"");
 public object ContentProvider => Document.Get(""ContentProvider"");

--- a/tests/extensions/Statiq.Json.Tests/ParseJsonFixture.cs
+++ b/tests/extensions/Statiq.Json.Tests/ParseJsonFixture.cs
@@ -36,7 +36,7 @@ namespace Statiq.Json.Tests
                 TestDocument result = await ExecuteAsync(document, json).SingleAsync();
 
                 // Then
-                result.Count.ShouldBe(5); // Includes property metadata
+                result.Count.ShouldBe(4); // Includes property metadata
                 result["MyJson"].ShouldBeOfType<ExpandoObject>();
                 ((string)((dynamic)result["MyJson"]).Email).ShouldBe("james@example.com");
                 ((bool)((dynamic)result["MyJson"]).Active).ShouldBeTrue();
@@ -55,7 +55,7 @@ namespace Statiq.Json.Tests
                 TestDocument result = await ExecuteAsync(document, json).SingleAsync();
 
                 // Then
-                result.Count.ShouldBe(8); // Includes property metadata
+                result.Count.ShouldBe(7); // Includes property metadata
                 ((string)result["Email"]).ShouldBe("james@example.com");
                 ((bool)result["Active"]).ShouldBeTrue();
                 ((DateTime)result["CreatedDate"]).ShouldBe(new DateTime(2013, 1, 20, 0, 0, 0, DateTimeKind.Utc));

--- a/tests/extensions/Statiq.Yaml.Tests/ParseYamlFixture.cs
+++ b/tests/extensions/Statiq.Yaml.Tests/ParseYamlFixture.cs
@@ -24,7 +24,7 @@ namespace Statiq.Yaml.Tests
                 TestDocument result = await ExecuteAsync(document, yaml).SingleAsync();
 
                 // Then
-                result.Keys.ShouldBe(new[] { "MyYaml", "Id", "Source", "Destination", "ContentProvider" }, true);
+                result.Keys.ShouldBe(new[] { "MyYaml", "Source", "Destination", "ContentProvider" }, true);
             }
 
             [Test]
@@ -42,7 +42,7 @@ C: Yes
                 TestDocument result = await ExecuteAsync(document, yaml).SingleAsync();
 
                 // Then
-                result.Keys.ShouldBe(new[] { "MyYaml", "Id", "Source", "Destination", "ContentProvider" }, true);
+                result.Keys.ShouldBe(new[] { "MyYaml", "Source", "Destination", "ContentProvider" }, true);
                 result["MyYaml"].ShouldBeOfType<DynamicYaml>();
                 ((int)((dynamic)result["MyYaml"]).A).ShouldBe(1);
                 ((bool)((dynamic)result["MyYaml"]).B).ShouldBe(true);
@@ -64,7 +64,7 @@ C: Yes
                 TestDocument result = await ExecuteAsync(document, yaml).SingleAsync();
 
                 // Then
-                result.Keys.ShouldBe(new[] { "A", "B", "C", "Id", "Source", "Destination", "ContentProvider" }, true);
+                result.Keys.ShouldBe(new[] { "A", "B", "C", "Source", "Destination", "ContentProvider" }, true);
                 result["A"].ShouldBe("1");
                 result["B"].ShouldBe("true");
                 result["C"].ShouldBe("Yes");
@@ -85,7 +85,7 @@ C: Yes
                 TestDocument result = await ExecuteAsync(document, yaml).SingleAsync();
 
                 // Then
-                result.Keys.ShouldBe(new[] { "MyYaml", "A", "B", "C", "Id", "Source", "Destination", "ContentProvider" }, true);
+                result.Keys.ShouldBe(new[] { "MyYaml", "A", "B", "C", "Source", "Destination", "ContentProvider" }, true);
                 result["MyYaml"].ShouldBeOfType<DynamicYaml>();
                 ((int)((dynamic)result["MyYaml"]).A).ShouldBe(1);
                 ((bool)((dynamic)result["MyYaml"]).B).ShouldBe(true);
@@ -107,7 +107,7 @@ C: Yes
                 TestDocument result = await ExecuteAsync(document, yaml).SingleAsync();
 
                 // Then
-                result.Keys.ShouldBe(new[] { "Id", "Source", "Destination", "ContentProvider" }, true);
+                result.Keys.ShouldBe(new[] { "Source", "Destination", "ContentProvider" }, true);
             }
 
             [Test]
@@ -142,14 +142,14 @@ C:
                 TestDocument result = await ExecuteAsync(document, yaml).SingleAsync();
 
                 // Then
-                result.Keys.ShouldBe(new[] { "C", "Id", "Source", "Destination", "ContentProvider" }, true);
+                result.Keys.ShouldBe(new[] { "C", "Source", "Destination", "ContentProvider" }, true);
                 result["C"].ShouldBeOfType<IDocument[]>();
                 IDocument[] subDocuments = (IDocument[])result["C"];
                 subDocuments.Length.ShouldBe(2);
-                subDocuments[0].Keys.ShouldBe(new[] { "X", "Y", "Id", "Source", "Destination", "ContentProvider" }, true);
+                subDocuments[0].Keys.ShouldBe(new[] { "X", "Y", "Source", "Destination", "ContentProvider" }, true);
                 subDocuments[0]["X"].ShouldBe("1");
                 subDocuments[0]["Y"].ShouldBe("2");
-                subDocuments[1].Keys.ShouldBe(new[] { "X", "Z", "Id", "Source", "Destination", "ContentProvider" }, true);
+                subDocuments[1].Keys.ShouldBe(new[] { "X", "Z", "Source", "Destination", "ContentProvider" }, true);
                 subDocuments[1]["X"].ShouldBe("4");
                 subDocuments[1]["Z"].ShouldBe("5");
             }


### PR DESCRIPTION
This PR fixes some issues around CacheDocuments

- We don't want to expose `Id` as metadata, this is problematic when calculating the hash as Id will always differ.
- Add a test for CacheDocuments so we don't break it.
- Fix invalid log message about cache miss in CacheDocuments
- Exclude `ContentProvider` when calculating cache. We already add the CRC of the content.