### PR TITLE
Razor custom view model breaks with Layout

### DIFF
--- a/src/extensions/Statiq.Razor/StatiqDocumentPhase.cs
+++ b/src/extensions/Statiq.Razor/StatiqDocumentPhase.cs
@@ -23,9 +23,7 @@ namespace Statiq.Razor
             NamespaceDeclarationIntermediateNode namespaceDeclaration =
                 documentNode.Children.OfType<NamespaceDeclarationIntermediateNode>().Single();
 
-            // Get the current model type, replacing default of dynamic with IDocument
             string modelType = ModelDirective.GetModelType(documentNode);
-            modelType = modelType == "dynamic" ? "IDocument" : modelType;
 
             // Set the base page type and perform default model type substitution here
             ClassDeclarationIntermediateNode classDeclaration =

--- a/tests/extensions/Statiq.Razor.Tests/RenderRazorFixture.cs
+++ b/tests/extensions/Statiq.Razor.Tests/RenderRazorFixture.cs
@@ -120,6 +120,29 @@ namespace Statiq.Razor.Tests
             }
 
             [Test]
+            public async Task AlternateModelWithLayout()
+            {
+                // Given
+                Engine engine = new Engine();
+                TestExecutionContext context = GetExecutionContext(engine);
+                TestDocument document = GetDocument(
+                    "/ViewStartAndLayout/Test.cshtml",
+                    @"@model int[]
+<p>This is a test</p>");
+                IList<int> model = new[] { 1, 2, 3 };
+                RenderRazor razor = new RenderRazor().WithModel(Config.FromValue(model));
+
+                // When
+                TestDocument result = await ExecuteAsync(document, context, razor).SingleAsync();
+
+                // Then
+                result.Content.ShouldBe(
+                    @"LAYOUT2
+<p>This is a test</p>",
+                    StringCompareShould.IgnoreLineEndings);
+            }
+
+            [Test]
             public async Task LoadLayoutFile()
             {
                 // Given


### PR DESCRIPTION
This resolves issue #23 but may be a breaking change for anyone assuming IDocument as the model for the Layout razor view.