### PR TITLE
Adds ReadApiWithClient module

### DIFF
--- a/Statiq.Framework.sln
+++ b/Statiq.Framework.sln
@@ -101,7 +101,11 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Statiq.Handlebars.Tests", "
 EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "build", "build", "{5904F60D-39EF-4521-B993-925F87264A31}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Statiq.Framework.Build", "build\Statiq.Framework.Build\Statiq.Framework.Build.csproj", "{D5FF0DD8-E009-487B-ABF1-2498E6122D67}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Statiq.Framework.Build", "build\Statiq.Framework.Build\Statiq.Framework.Build.csproj", "{D5FF0DD8-E009-487B-ABF1-2498E6122D67}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Statiq.ApiClient", "src\extensions\Statiq.ApiClient\Statiq.ApiClient.csproj", "{D6CAAEF2-2409-4074-8CBD-A05BF22FD864}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Statiq.ApiClient.Tests", "tests\extensions\Statiq.ApiClient.Tests\Statiq.ApiClient.Tests.csproj", "{28D1E15D-2F8D-4C8D-B6A1-8C723C77FF76}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -269,6 +273,14 @@ Global
 		{D5FF0DD8-E009-487B-ABF1-2498E6122D67}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{D5FF0DD8-E009-487B-ABF1-2498E6122D67}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{D5FF0DD8-E009-487B-ABF1-2498E6122D67}.Release|Any CPU.Build.0 = Release|Any CPU
+		{D6CAAEF2-2409-4074-8CBD-A05BF22FD864}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{D6CAAEF2-2409-4074-8CBD-A05BF22FD864}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{D6CAAEF2-2409-4074-8CBD-A05BF22FD864}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{D6CAAEF2-2409-4074-8CBD-A05BF22FD864}.Release|Any CPU.Build.0 = Release|Any CPU
+		{28D1E15D-2F8D-4C8D-B6A1-8C723C77FF76}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{28D1E15D-2F8D-4C8D-B6A1-8C723C77FF76}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{28D1E15D-2F8D-4C8D-B6A1-8C723C77FF76}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{28D1E15D-2F8D-4C8D-B6A1-8C723C77FF76}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -318,6 +330,8 @@ Global
 		{CD461A93-0245-45B9-A4C6-2C0D7FEDC67D} = {5A431149-2B88-40C3-9717-CA6CCF214317}
 		{3FCF3A84-35F4-49BC-B58C-098BB1B6A6DA} = {2E5842F3-4797-4BB5-9A55-F3A005B434F8}
 		{D5FF0DD8-E009-487B-ABF1-2498E6122D67} = {5904F60D-39EF-4521-B993-925F87264A31}
+		{D6CAAEF2-2409-4074-8CBD-A05BF22FD864} = {5A431149-2B88-40C3-9717-CA6CCF214317}
+		{28D1E15D-2F8D-4C8D-B6A1-8C723C77FF76} = {2E5842F3-4797-4BB5-9A55-F3A005B434F8}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {B0CD133C-B843-4178-8976-B04AE6B2021A}

--- a/src/extensions/Statiq.ApiClient/ReadApiWithClient.cs
+++ b/src/extensions/Statiq.ApiClient/ReadApiWithClient.cs
@@ -1,0 +1,114 @@
+﻿using System;
+using System.Collections.Concurrent;
+using System.Collections.Generic;
+using Microsoft.Extensions.Logging;
+using Statiq.Common;
+
+namespace Statiq.ApiClient
+{
+    /// <summary>
+    /// Outputs metadata for information from any API with its client.
+    /// </summary>
+    /// <remarks>
+    /// This modules used to submit requests to the API with the API client. Because of the possible large
+    /// number of different kinds of requests, this module does not attempt to provide a fully abstract wrapper
+    /// around the API. Instead, it simplifies the housekeeping involved in setting up an
+    /// API client and requires you to provide functions that fetch whatever data you need. Each request
+    /// will be sent for each input document.
+    /// </remarks>
+    /// <category>Metadata</category>
+    public class ReadApiWithClient<TClient> : ParallelSyncModule
+        where TClient : class
+    {
+        private readonly Dictionary<string, Func<IDocument, IExecutionContext, TClient, object>> _requests
+            = new Dictionary<string, Func<IDocument, IExecutionContext, TClient, object>>();
+
+        private readonly TClient _client;
+
+        private string _clientName;
+
+        /// <summary>
+        /// Creates a connection to the API using client.
+        /// </summary>
+        /// <param name="client">The API client to use.</param>
+        public ReadApiWithClient(TClient client)
+        {
+            _client = client;
+        }
+
+        /// <summary>
+        /// Initialize the API client.
+        /// </summary>
+        /// <param name="init">API client initialization action.</param>
+        /// <returns>The current module instance.</returns>
+        public ReadApiWithClient<TClient> WithClientInitialization(Action<TClient> init)
+        {
+            if (init == null)
+            {
+                throw new ArgumentException("Argument is null or empty", nameof(init));
+            }
+
+            init.Invoke(_client);
+            return this;
+        }
+
+        /// <summary>
+        /// Submits the API client name (for logging).
+        /// </summary>
+        /// <param name="name">Client name.</param>
+        /// <returns>The current module instance.</returns>
+        public ReadApiWithClient<TClient> WithClientName(string name)
+        {
+            _clientName = name;
+            return this;
+        }
+
+        /// <summary>
+        /// Submits a request to the API client. This allows you to incorporate data from the execution context in your request.
+        /// </summary>
+        /// <param name="key">The metadata key in which to store the return value of the request function.</param>
+        /// <param name="request">A function with the request to make.</param>
+        /// <returns>The current module instance.</returns>
+        public ReadApiWithClient<TClient> WithRequest(string key, Func<IExecutionContext, TClient, object> request)
+        {
+            key.ThrowIfNullOrEmpty(nameof(key));
+            request.ThrowIfNull(nameof(request));
+
+            _requests[key] = (doc, ctx, client) => request(ctx, client);
+            return this;
+        }
+
+        /// <summary>
+        /// Submits a request to the API. This allows you to incorporate data from the execution context and current document in your request.
+        /// </summary>
+        /// <param name="key">The metadata key in which to store the return value of the request function.</param>
+        /// <param name="request">A function with the request to make.</param>
+        /// <returns>The current module instance.</returns>
+        public ReadApiWithClient<TClient> WithRequest(string key, Func<IDocument, IExecutionContext, TClient, object> request)
+        {
+            key.ThrowIfNullOrEmpty(nameof(key));
+
+            _requests[key] = request.ThrowIfNull(nameof(request));
+            return this;
+        }
+
+        /// <inheritdoc/>
+        protected override IEnumerable<IDocument> ExecuteInput(IDocument input, IExecutionContext context)
+        {
+            ConcurrentDictionary<string, object> results = new ConcurrentDictionary<string, object>();
+            System.Threading.Tasks.Parallel.ForEach(_requests, request =>
+            {
+                context.LogDebug("Submitting {0} {1} request for {2}", request.Key, _clientName, input.ToSafeDisplayString());
+                try
+                {
+                    results[request.Key] = request.Value(input, context, _client);
+                }
+                catch (Exception ex)
+                {
+                    context.LogWarning("Exception while submitting {0} {1} request for {2}: {3}", request.Key, _clientName, input.ToSafeDisplayString(), ex.ToString());
+                }
+            });
+            return input.Clone(results).Yield();
+        }
+    }
+}

--- a/src/extensions/Statiq.ApiClient/Statiq.ApiClient.csproj
+++ b/src/extensions/Statiq.ApiClient/Statiq.ApiClient.csproj
@@ -1,0 +1,14 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <OutputType>Library</OutputType>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <Description>Statiq is a configurable static content generation framework. This library provides support for interacting with API using the API client.</Description>
+    <PackageTags>Statiq Static StaticContent StaticSite Blog BlogEngine API Client</PackageTags>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\core\Statiq.Common\Statiq.Common.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/tests/extensions/Statiq.ApiClient.Tests/ReadApiWithClientFixture.cs
+++ b/tests/extensions/Statiq.ApiClient.Tests/ReadApiWithClientFixture.cs
@@ -1,0 +1,48 @@
+﻿using System.Net.Http;
+using System.Threading.Tasks;
+using NUnit.Framework;
+using Shouldly;
+using Statiq.Common;
+using Statiq.Testing;
+
+namespace Statiq.ApiClient.Tests
+{
+    /// <summary>
+    /// Test fixture for <see cref="ReadApiWithClient{TClient}"/>.
+    /// </summary>
+    [TestFixture]
+    public class ReadApiWithClientFixture : BaseFixture
+    {
+        /// <summary>
+        /// Tests for execute method.
+        /// </summary>
+        public class ExecuteTests : ReadApiWithClientFixture
+        {
+            /// <summary>
+            /// Sets the metadata from the requests.
+            /// </summary>
+            [Test]
+            public async Task SetsMetadata()
+            {
+                // Given
+                HttpClient httpClient = new HttpClient();
+                TestDocument document = new TestDocument();
+                IModule client = new ReadApiWithClient<HttpClient>(httpClient)
+                    .WithClientInitialization(c =>
+                    {
+                        c.DefaultRequestHeaders.Add("Authorization", "Bearer ...");
+                    })
+                    .WithClientName(nameof(HttpClient))
+                    .WithRequest("Foo", (ctx, yt) => 1)
+                    .WithRequest("Bar", (doc, ctx, yt) => "baz");
+
+                // When
+                TestDocument result = await ExecuteAsync(document, client).SingleAsync();
+
+                // Then
+                result["Foo"].ShouldBe(1);
+                result["Bar"].ShouldBe("baz");
+            }
+        }
+    }
+}

--- a/tests/extensions/Statiq.ApiClient.Tests/Statiq.ApiClient.Tests.csproj
+++ b/tests/extensions/Statiq.ApiClient.Tests/Statiq.ApiClient.Tests.csproj
@@ -1,0 +1,21 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
+
+    <IsPackable>false</IsPackable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="nunit" Version="3.12.0" />
+    <PackageReference Include="NUnit3TestAdapter" Version="3.15.1" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.4.0" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\..\src\core\Statiq.Core\Statiq.Core.csproj" />
+    <ProjectReference Include="..\..\..\src\core\Statiq.Testing\Statiq.Testing.csproj" />
+    <ProjectReference Include="..\..\..\src\extensions\Statiq.ApiClient\Statiq.ApiClient.csproj" />
+  </ItemGroup>
+
+</Project>


### PR DESCRIPTION
Adds ReadApiWithClient module that allows to output metadata for information from any API with its client.

For example, for [Google.Apis.YouTube.v3](https://github.com/googleapis/google-api-dotnet-client) or [SpotifyAPI-NET](https://github.com/JohnnyCrazy/SpotifyAPI-NET) or [Telegram.Bot](https://github.com/TelegramBots/Telegram.Bot) or more other clients.