### PR TITLE
Update ImageSharp to Stable Build.

### DIFF
--- a/src/extensions/Statiq.Images/ActionOperation.cs
+++ b/src/extensions/Statiq.Images/ActionOperation.cs
@@ -1,5 +1,4 @@
 ﻿using System;
-using SixLabors.ImageSharp.PixelFormats;
 using SixLabors.ImageSharp.Processing;
 using Statiq.Common;
 
@@ -7,18 +6,18 @@ namespace Statiq.Images.Operations
 {
     internal class ActionOperation : IImageOperation
     {
-        private readonly Func<IImageProcessingContext<Rgba32>, IImageProcessingContext<Rgba32>> _operation;
+        private readonly Func<IImageProcessingContext, IImageProcessingContext> _operation;
         private readonly Func<NormalizedPath, NormalizedPath> _pathModifier;
 
         public ActionOperation(
-            Func<IImageProcessingContext<Rgba32>, IImageProcessingContext<Rgba32>> operation,
+            Func<IImageProcessingContext, IImageProcessingContext> operation,
             Func<NormalizedPath, NormalizedPath> pathModifier)
         {
             _operation = operation;
             _pathModifier = pathModifier;
         }
 
-        public IImageProcessingContext<Rgba32> Apply(IImageProcessingContext<Rgba32> image) =>
+        public IImageProcessingContext Apply(IImageProcessingContext image) =>
             _operation is null ? image : _operation(image);
 
         public NormalizedPath GetPath(NormalizedPath path) =>

--- a/src/extensions/Statiq.Images/IImageOperation.cs
+++ b/src/extensions/Statiq.Images/IImageOperation.cs
@@ -1,12 +1,11 @@
-﻿using SixLabors.ImageSharp.PixelFormats;
-using SixLabors.ImageSharp.Processing;
+﻿using SixLabors.ImageSharp.Processing;
 using Statiq.Common;
 
 namespace Statiq.Images.Operations
 {
     internal interface IImageOperation
     {
-        IImageProcessingContext<Rgba32> Apply(IImageProcessingContext<Rgba32> image);
+        IImageProcessingContext Apply(IImageProcessingContext image);
         NormalizedPath GetPath(NormalizedPath path);
     }
 }

--- a/src/extensions/Statiq.Images/MutateImage.cs
+++ b/src/extensions/Statiq.Images/MutateImage.cs
@@ -2,14 +2,10 @@
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
-using System.Threading.Tasks;
 using SixLabors.ImageSharp;
 using SixLabors.ImageSharp.Formats;
 using SixLabors.ImageSharp.PixelFormats;
 using SixLabors.ImageSharp.Processing;
-using SixLabors.ImageSharp.Processing.Filters;
-using SixLabors.ImageSharp.Processing.Overlays;
-using SixLabors.ImageSharp.Processing.Transforms;
 using Statiq.Common;
 using Statiq.Images.Operations;
 
@@ -137,7 +133,7 @@ namespace Statiq.Images
         /// <param name="pathModifier">Modifies the destination path after applying the operation.</param>
         /// <returns>The current module instance.</returns>
         public MutateImage Operation(
-            Func<IImageProcessingContext<Rgba32>, IImageProcessingContext<Rgba32>> operation,
+            Func<IImageProcessingContext, IImageProcessingContext> operation,
             Func<NormalizedPath, NormalizedPath> pathModifier = null)
         {
             _operations.Peek().Enqueue(new ActionOperation(operation, pathModifier));
@@ -222,11 +218,11 @@ namespace Statiq.Images
         }
 
         /// <summary>
-        /// Apply vignette processing to the image with specific color, e.g. <c>Vignette(Rgba32.AliceBlue)</c>.
+        /// Apply vignette processing to the image with specific color, e.g. <c>Vignette(Color.AliceBlue)</c>.
         /// </summary>
         /// <param name="color">The color to use for the vignette.</param>
         /// <returns>The current module instance.</returns>
-        public MutateImage Vignette(Rgba32 color)
+        public MutateImage Vignette(Color color)
         {
             _operations.Peek().Enqueue(new ActionOperation(
                 image => image.Vignette(color),
@@ -323,7 +319,7 @@ namespace Statiq.Images
                 IImageFormat imageFormat;
                 using (Stream stream = input.GetContentStream())
                 {
-                    image = SixLabors.ImageSharp.Image.Load(stream, out imageFormat);
+                    image = Image.Load<Rgba32>(stream, out imageFormat);
                 }
 
                 // Mutate the image with the specified operations, if there are any
@@ -331,7 +327,7 @@ namespace Statiq.Images
                 {
                     image.Mutate(imageContext =>
                     {
-                        IImageProcessingContext<Rgba32> workingImageContext = imageContext;
+                        IImageProcessingContext workingImageContext = imageContext;
                         foreach (IImageOperation operation in operations.Operations)
                         {
                             // Apply operation

--- a/src/extensions/Statiq.Images/ResizeOperation.cs
+++ b/src/extensions/Statiq.Images/ResizeOperation.cs
@@ -1,7 +1,5 @@
-﻿using SixLabors.ImageSharp.PixelFormats;
+﻿using SixLabors.ImageSharp;
 using SixLabors.ImageSharp.Processing;
-using SixLabors.ImageSharp.Processing.Transforms;
-using SixLabors.Primitives;
 using Statiq.Common;
 
 namespace Statiq.Images.Operations
@@ -21,7 +19,7 @@ namespace Statiq.Images.Operations
             _anchor = anchor;
         }
 
-        public IImageProcessingContext<Rgba32> Apply(IImageProcessingContext<Rgba32> image)
+        public IImageProcessingContext Apply(IImageProcessingContext image)
         {
             Size? size = GetSize();
             if (size is null)

--- a/src/extensions/Statiq.Images/Statiq.Images.csproj
+++ b/src/extensions/Statiq.Images/Statiq.Images.csproj
@@ -4,7 +4,7 @@
     <PackageTags>Statiq Static StaticContent StaticSite Blog BlogEngine Images ImageProcessor</PackageTags>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="SixLabors.ImageSharp" Version="1.0.0-beta0004" />
+    <PackageReference Include="SixLabors.ImageSharp" Version="1.0.1" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\..\core\Statiq.Common\Statiq.Common.csproj" />


### PR DESCRIPTION
Simple upgrade from the old beta. 

Two breaking changes from the beta to `MutateImage`.  

`Vignette(Rgba32 color)` is now `Vignette(Color color)`

```
Operation(
        Func<IImageProcessingContext<Rgba32>, IImageProcessingContext<Rgba32>> operation,
        Func<NormalizedPath, NormalizedPath> pathModifier = null)
```

Is now 

```
Operation(
        Func<IImageProcessingContext, IImageProcessingContext> operation,
        Func<NormalizedPath, NormalizedPath> pathModifier = null)
```