### PR TITLE
ViewData support for Razor views

### DIFF
--- a/src/extensions/Statiq.Razor/RazorCompiler.cs
+++ b/src/extensions/Statiq.Razor/RazorCompiler.cs
@@ -152,6 +152,14 @@ namespace Statiq.Razor
                 Model = request.Model
             };
 
+            if (request.ViewData != null)
+            {
+                foreach (KeyValuePair<string, object> pair in request.ViewData)
+                {
+                    viewData.Add(pair);
+                }
+            }
+
             ITempDataDictionary tempData = new TempDataDictionary(actionContext.HttpContext, serviceProvider.GetRequiredService<ITempDataProvider>());
 
             return new ViewContext(

--- a/src/extensions/Statiq.Razor/RenderRequest.cs
+++ b/src/extensions/Statiq.Razor/RenderRequest.cs
@@ -28,6 +28,6 @@ namespace Statiq.Razor
 
         public IDocument Document { get; set; }
 
-        public IEnumerable<KeyValuePair<string,object>> ViewData { get; set; }
+        public IEnumerable<KeyValuePair<string, object>> ViewData { get; set; }
     }
 }

--- a/src/extensions/Statiq.Razor/RenderRequest.cs
+++ b/src/extensions/Statiq.Razor/RenderRequest.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Collections.Generic;
 using System.IO;
 using Statiq.Common;
 
@@ -26,5 +27,7 @@ namespace Statiq.Razor
         public IExecutionContext Context { get; set; }
 
         public IDocument Document { get; set; }
+
+        public IEnumerable<KeyValuePair<string,object>> ViewData { get; set; }
     }
 }

--- a/tests/extensions/Statiq.Razor.Tests/RenderRazorFixture.cs
+++ b/tests/extensions/Statiq.Razor.Tests/RenderRazorFixture.cs
@@ -1,15 +1,13 @@
-﻿using System.Collections.Generic;
-using System.Collections.Immutable;
+﻿using System;
+using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
 using Microsoft.Extensions.DependencyInjection;
-using Microsoft.Extensions.Logging;
 using NUnit.Framework;
 using Shouldly;
 using Statiq.Common;
 using Statiq.Core;
 using Statiq.Testing;
-using System;
 
 namespace Statiq.Razor.Tests
 {
@@ -178,12 +176,12 @@ namespace Statiq.Razor.Tests
                 TestDocument document = GetDocument(
                     "/input/Temp/temp.txt",
                     @"<p></p>");
-                
+
                 RenderRazor razor = new RenderRazor()
                     .WithViewData("Test", Config.FromContext(ctx => throw new InvalidOperationException("Kaboom")));
 
                 // When
-                var exception = await Should.ThrowAsync<InvalidOperationException>(  () => ExecuteAsync(document, context, razor).SingleAsync() );
+                InvalidOperationException exception = await Should.ThrowAsync<InvalidOperationException>(() => ExecuteAsync(document, context, razor).SingleAsync());
 
                 // Then
                 exception.Message.ShouldContain("'Test'");


### PR DESCRIPTION
See issue #145

* Multiple view data items can be added 
* If an exception occurs while resolving the value of a view data item, the exception is rethrown with additional infor so the dev knows _what_ view data item caused the issue.