### PR TITLE
(GH-160) Remove invalid space in doctype element

### DIFF
--- a/src/core/Statiq.Core/Modules/Content/GenerateRedirects.cs
+++ b/src/core/Statiq.Core/Modules/Content/GenerateRedirects.cs
@@ -159,7 +159,7 @@ namespace Statiq.Core
                                 outputPath,
                                 context.GetContentProvider(
                                     $@"
-< !doctype html>
+<!doctype html>
 <html>    
   <head>      
     <title>Redirected</title>      


### PR DESCRIPTION
This is causing invalid HTML to be generated for each redirect page.

Fixes #160 