### PR TITLE
Replace Spectre.Cli with Spectre.Console

### DIFF
--- a/src/core/Statiq.App/Bootstrapper/Bootstrapper.cs
+++ b/src/core/Statiq.App/Bootstrapper/Bootstrapper.cs
@@ -7,7 +7,7 @@ using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.DependencyInjection.Extensions;
 using Microsoft.Extensions.Logging;
-using Spectre.Cli;
+using Spectre.Console.Cli;
 using Statiq.Common;
 using Statiq.Core;
 

--- a/src/core/Statiq.App/Bootstrapper/BootstrapperCommandExtensions.cs
+++ b/src/core/Statiq.App/Bootstrapper/BootstrapperCommandExtensions.cs
@@ -3,8 +3,8 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Reflection;
 using Microsoft.Extensions.DependencyInjection;
-using Spectre.Cli;
-using Spectre.Cli.Unsafe;
+using Spectre.Console.Cli;
+using Spectre.Console.Cli.Unsafe;
 using Statiq.Common;
 
 namespace Statiq.App

--- a/src/core/Statiq.App/Bootstrapper/BootstrapperConfigurationExtensions.cs
+++ b/src/core/Statiq.App/Bootstrapper/BootstrapperConfigurationExtensions.cs
@@ -3,7 +3,7 @@ using System.Collections.Generic;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
-using Spectre.Cli;
+using Spectre.Console.Cli;
 using Statiq.Common;
 
 namespace Statiq.App

--- a/src/core/Statiq.App/Bootstrapper/BootstrapperExtensions.cs
+++ b/src/core/Statiq.App/Bootstrapper/BootstrapperExtensions.cs
@@ -3,7 +3,7 @@ using System.Collections.Generic;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
-using Spectre.Cli;
+using Spectre.Console.Cli;
 using Statiq.Common;
 
 namespace Statiq.App

--- a/src/core/Statiq.App/Bootstrapper/BootstrapperFactory.cs
+++ b/src/core/Statiq.App/Bootstrapper/BootstrapperFactory.cs
@@ -7,7 +7,7 @@ using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.DependencyInjection.Extensions;
 using Microsoft.Extensions.Logging;
-using Spectre.Cli;
+using Spectre.Console.Cli;
 using Statiq.Common;
 using Statiq.Core;
 

--- a/src/core/Statiq.App/Commands/BaseCommandSettings.cs
+++ b/src/core/Statiq.App/Commands/BaseCommandSettings.cs
@@ -1,6 +1,6 @@
 ﻿using System.ComponentModel;
 using Microsoft.Extensions.Logging;
-using Spectre.Cli;
+using Spectre.Console.Cli;
 
 namespace Statiq.App
 {

--- a/src/core/Statiq.App/Commands/BaseCommand{TSettings}.cs
+++ b/src/core/Statiq.App/Commands/BaseCommand{TSettings}.cs
@@ -6,7 +6,7 @@ using System.Threading.Tasks;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
 using NetEscapades.Extensions.Logging.RollingFile;
-using Spectre.Cli;
+using Spectre.Console.Cli;
 using Statiq.Common;
 
 namespace Statiq.App

--- a/src/core/Statiq.App/Commands/CommandServiceTypeRegistrar.cs
+++ b/src/core/Statiq.App/Commands/CommandServiceTypeRegistrar.cs
@@ -1,7 +1,7 @@
 ﻿using System;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
-using Spectre.Cli;
+using Spectre.Console.Cli;
 
 namespace Statiq.App
 {

--- a/src/core/Statiq.App/Commands/CommandServiceTypeResolver.cs
+++ b/src/core/Statiq.App/Commands/CommandServiceTypeResolver.cs
@@ -1,6 +1,6 @@
 ﻿using System;
 using Microsoft.Extensions.DependencyInjection;
-using Spectre.Cli;
+using Spectre.Console.Cli;
 using Statiq.Common;
 
 namespace Statiq.App

--- a/src/core/Statiq.App/Commands/DeployCommand.cs
+++ b/src/core/Statiq.App/Commands/DeployCommand.cs
@@ -1,7 +1,7 @@
 ﻿using System.ComponentModel;
 using System.Linq;
 using Microsoft.Extensions.DependencyInjection;
-using Spectre.Cli;
+using Spectre.Console.Cli;
 using Statiq.Common;
 using Statiq.Core;
 

--- a/src/core/Statiq.App/Commands/DeployCommandSettings.cs
+++ b/src/core/Statiq.App/Commands/DeployCommandSettings.cs
@@ -3,7 +3,7 @@ using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
-using Spectre.Cli;
+using Spectre.Console.Cli;
 using Statiq.Common;
 
 namespace Statiq.App

--- a/src/core/Statiq.App/Commands/EmptyCommandSettings.cs
+++ b/src/core/Statiq.App/Commands/EmptyCommandSettings.cs
@@ -4,7 +4,7 @@ using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
-using Spectre.Cli;
+using Spectre.Console.Cli;
 using Statiq.Common;
 
 namespace Statiq.App

--- a/src/core/Statiq.App/Commands/EngineCommandSettings.cs
+++ b/src/core/Statiq.App/Commands/EngineCommandSettings.cs
@@ -3,7 +3,7 @@ using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
-using Spectre.Cli;
+using Spectre.Console.Cli;
 using Statiq.Common;
 
 namespace Statiq.App

--- a/src/core/Statiq.App/Commands/EngineCommand{TSettings}.cs
+++ b/src/core/Statiq.App/Commands/EngineCommand{TSettings}.cs
@@ -1,6 +1,6 @@
 ﻿using System.Threading.Tasks;
 using Microsoft.Extensions.DependencyInjection;
-using Spectre.Cli;
+using Spectre.Console.Cli;
 using Statiq.Common;
 using Statiq.Core;
 

--- a/src/core/Statiq.App/Commands/EngineManager.cs
+++ b/src/core/Statiq.App/Commands/EngineManager.cs
@@ -6,7 +6,7 @@ using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
-using Spectre.Cli;
+using Spectre.Console.Cli;
 using Statiq.Common;
 using Statiq.Core;
 

--- a/src/core/Statiq.App/Commands/GlobCommandSettings.cs
+++ b/src/core/Statiq.App/Commands/GlobCommandSettings.cs
@@ -1,6 +1,6 @@
 ﻿using System;
 using System.Threading.Tasks;
-using Spectre.Cli;
+using Spectre.Console.Cli;
 
 namespace Statiq.App
 {

--- a/src/core/Statiq.App/Commands/GlobEvalCommand.cs
+++ b/src/core/Statiq.App/Commands/GlobEvalCommand.cs
@@ -5,7 +5,7 @@ using System.IO;
 using System.Linq;
 using System.Threading.Tasks;
 using Microsoft.VisualBasic;
-using Spectre.Cli;
+using Spectre.Console.Cli;
 using Statiq.Common;
 using Statiq.Core;
 

--- a/src/core/Statiq.App/Commands/GlobEvalCommandSettings.cs
+++ b/src/core/Statiq.App/Commands/GlobEvalCommandSettings.cs
@@ -1,5 +1,5 @@
 ﻿using System.ComponentModel;
-using Spectre.Cli;
+using Spectre.Console.Cli;
 
 namespace Statiq.App
 {

--- a/src/core/Statiq.App/Commands/GlobTestCommand.cs
+++ b/src/core/Statiq.App/Commands/GlobTestCommand.cs
@@ -3,7 +3,7 @@ using System.Collections.Generic;
 using System.ComponentModel;
 using System.Linq;
 using System.Threading.Tasks;
-using Spectre.Cli;
+using Spectre.Console.Cli;
 using Statiq.Common;
 using Statiq.Testing;
 

--- a/src/core/Statiq.App/Commands/GlobTestCommandSettings.cs
+++ b/src/core/Statiq.App/Commands/GlobTestCommandSettings.cs
@@ -1,5 +1,5 @@
 ﻿using System.ComponentModel;
-using Spectre.Cli;
+using Spectre.Console.Cli;
 
 namespace Statiq.App
 {

--- a/src/core/Statiq.App/Commands/IConfiguratorExtensions.cs
+++ b/src/core/Statiq.App/Commands/IConfiguratorExtensions.cs
@@ -1,6 +1,6 @@
 ﻿using System;
-using Spectre.Cli;
-using Spectre.Cli.Unsafe;
+using Spectre.Console.Cli;
+using Spectre.Console.Cli.Unsafe;
 using Statiq.Common;
 
 namespace Statiq.App

--- a/src/core/Statiq.App/Commands/InteractiveCommand.cs
+++ b/src/core/Statiq.App/Commands/InteractiveCommand.cs
@@ -10,7 +10,7 @@ using Microsoft.CodeAnalysis.CSharp.Scripting;
 using Microsoft.CodeAnalysis.Scripting;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
-using Spectre.Cli;
+using Spectre.Console.Cli;
 using Statiq.Common;
 
 namespace Statiq.App

--- a/src/core/Statiq.App/Commands/PipelinesCommandSettings.cs
+++ b/src/core/Statiq.App/Commands/PipelinesCommandSettings.cs
@@ -1,5 +1,5 @@
 ﻿using System.ComponentModel;
-using Spectre.Cli;
+using Spectre.Console.Cli;
 
 namespace Statiq.App
 {

--- a/src/core/Statiq.App/Commands/PipelinesCommand{TSettings}.cs
+++ b/src/core/Statiq.App/Commands/PipelinesCommand{TSettings}.cs
@@ -3,7 +3,7 @@ using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
-using Spectre.Cli;
+using Spectre.Console.Cli;
 using Statiq.Common;
 using Statiq.Core;
 

--- a/src/core/Statiq.App/Configuration/ConfigurableCommands.cs
+++ b/src/core/Statiq.App/Configuration/ConfigurableCommands.cs
@@ -6,11 +6,11 @@ namespace Statiq.App
 {
     public class ConfigurableCommands : IConfigurable
     {
-        internal ConfigurableCommands(Spectre.Cli.IConfigurator configurator)
+        internal ConfigurableCommands(Spectre.Console.Cli.IConfigurator configurator)
         {
             Configurator = configurator;
         }
 
-        public Spectre.Cli.IConfigurator Configurator { get; }
+        public Spectre.Console.Cli.IConfigurator Configurator { get; }
     }
 }

--- a/src/core/Statiq.App/Statiq.App.csproj
+++ b/src/core/Statiq.App/Statiq.App.csproj
@@ -21,7 +21,7 @@
     <PackageReference Include="Microsoft.Extensions.Logging.Debug" Version="3.0.0" />
     <PackageReference Include="NetEscapades.Configuration.Yaml" Version="2.0.1" />
     <PackageReference Include="NetEscapades.Extensions.Logging.RollingFile" Version="2.2.0" />
-    <PackageReference Include="Spectre.Cli" Version="0.36.0" />
+    <PackageReference Include="Spectre.Console" Version="0.37.0" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
Since `Spectre.Cli` has been merged into [Spectre.Console](https://github.com/spectresystems/spectre.console), I thought I would send a PR to make the transition in Statiq. This change will need to be done in Statiq.Web as well once this has been merged.