### PR TITLE
Fixed Spectre.Console escaping

### DIFF
--- a/src/core/Statiq.App/Commands/BaseCommandSettings.cs
+++ b/src/core/Statiq.App/Commands/BaseCommandSettings.cs
@@ -23,7 +23,7 @@ namespace Statiq.App
         public string LogFile { get; set; }
 
         [CommandOption("-s|--setting <SETTING>")]
-        [Description("Specifies a setting as a \"[key]=[value]\" pair (the value can be omited).")]
+        [Description("Specifies a setting as a \"[[key]]=[[value]]\" pair (the value can be omited).")]
         public string[] Settings { get; set; }
 
         [CommandOption("--failure-log-level <LEVEL>")]


### PR DESCRIPTION
Fixes #180 according to https://spectresystems.github.io/spectre.console/markup#escaping-format-characters