### PR TITLE
Fixed issue with Markdown failing to create link from absolute URL without http/https in it

### DIFF
--- a/src/extensions/Statiq.Markdown/MarkdownHelper.cs
+++ b/src/extensions/Statiq.Markdown/MarkdownHelper.cs
@@ -51,9 +51,9 @@ namespace Statiq.Markdown
                         return link;
                     }
 
-                    if (!RelativeUrl.IsRelative(link) && LinkGenerator.TryGetAbsoluteHttpUri(link, out string absoluteUri))
+                    if (!RelativeUrl.IsRelative(link))
                     {
-                        return absoluteUri;
+                        return LinkGenerator.TryGetAbsoluteHttpUri(link, out string absoluteUri) ? absoluteUri : link;
                     }
 
                     // TODO: Remove when RenderMarkdown.PrependLinkRoot goes away.


### PR DESCRIPTION
Closes #179