### PR TITLE
Update Microsoft.Extensions.* references

### DIFF
--- a/src/core/Statiq.App/Statiq.App.csproj
+++ b/src/core/Statiq.App/Statiq.App.csproj
@@ -12,13 +12,13 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Scripting" Version="3.8.0" />
-    <PackageReference Include="Microsoft.Extensions.Configuration.CommandLine" Version="3.0.0" />
-    <PackageReference Include="Microsoft.Extensions.Configuration.EnvironmentVariables" Version="3.0.0" />
-    <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="3.0.0" />
-    <PackageReference Include="Microsoft.Extensions.Configuration.Xml" Version="3.0.0" />
-    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="3.0.0" />
-    <PackageReference Include="Microsoft.Extensions.Logging" Version="3.0.0" />
-    <PackageReference Include="Microsoft.Extensions.Logging.Debug" Version="3.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.CommandLine" Version="3.1.18" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.EnvironmentVariables" Version="3.1.18" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="3.1.18" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.Xml" Version="3.1.18" />
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="3.1.18" />
+    <PackageReference Include="Microsoft.Extensions.Logging" Version="3.1.18" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Debug" Version="3.1.18" />
     <PackageReference Include="NetEscapades.Configuration.Yaml" Version="2.0.1" />
     <PackageReference Include="NetEscapades.Extensions.Logging.RollingFile" Version="2.2.0" />
     <PackageReference Include="Spectre.Console" Version="0.39.0" />

--- a/src/core/Statiq.Common/Statiq.Common.csproj
+++ b/src/core/Statiq.Common/Statiq.Common.csproj
@@ -5,11 +5,11 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="ConcurrentHashSet" Version="1.1.0" />
-    <PackageReference Include="Microsoft.Extensions.Configuration.Abstractions" Version="3.0.0" />
-    <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="3.0.0" />
-    <PackageReference Include="Microsoft.Extensions.DependencyModel" Version="3.1.3" />
-    <PackageReference Include="Microsoft.Extensions.FileSystemGlobbing" Version="3.0.0" />
-    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="3.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.Abstractions" Version="3.1.18" />
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="3.1.18" />
+    <PackageReference Include="Microsoft.Extensions.DependencyModel" Version="3.1.6" />
+    <PackageReference Include="Microsoft.Extensions.FileSystemGlobbing" Version="3.1.18" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="3.1.18" />
   </ItemGroup>
   <ItemGroup>
     <AssemblyAttribute Include="System.Runtime.CompilerServices.InternalsVisibleTo">

--- a/src/core/Statiq.Core/Statiq.Core.csproj
+++ b/src/core/Statiq.Core/Statiq.Core.csproj
@@ -8,7 +8,7 @@
     <PackageReference Include="JavaScriptEngineSwitcher.Jint" Version="3.0.0" />
     <PackageReference Include="JSPool" Version="2.0.1" />
     <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="3.8.0" />
-    <PackageReference Include="Microsoft.Extensions.Logging" Version="3.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Logging" Version="3.1.18" />
     <PackageReference Include="Microsoft.IO.RecyclableMemoryStream" Version="1.2.2" />
     <PackageReference Include="Polly" Version="7.1.1" />
     <PackageReference Include="SemanticVersioning" Version="1.2.2" />

--- a/src/core/Statiq.Testing/Statiq.Testing.csproj
+++ b/src/core/Statiq.Testing/Statiq.Testing.csproj
@@ -4,8 +4,8 @@
     <PackageTags>Statiq Static StaticContent StaticSite Blog BlogEngine</PackageTags>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="3.0.0" />
-    <PackageReference Include="Microsoft.Extensions.Logging" Version="3.0.0" />
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="3.1.18" />
+    <PackageReference Include="Microsoft.Extensions.Logging" Version="3.1.18" />
     <PackageReference Include="NUnit" Version="3.12.0" />
     <PackageReference Include="Shouldly" Version="4.0.3">
       <!-- See https://github.com/shouldly/shouldly/issues/795 -->

--- a/src/extensions/Statiq.Razor/Statiq.Razor.csproj
+++ b/src/extensions/Statiq.Razor/Statiq.Razor.csproj
@@ -10,9 +10,9 @@
     <PackageReference Include="Microsoft.AspNetCore.Razor.Language" Version="3.1.15" />
     <PackageReference Include="Microsoft.AspNetCore.Mvc.Razor.RuntimeCompilation" Version="3.1.15" />
     <PackageReference Include="Microsoft.AspNetCore.Mvc.Razor.Extensions" Version="3.1.15" />
-    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="3.0.0" />
-    <PackageReference Include="Microsoft.Extensions.FileProviders.Composite" Version="3.0.0" />
-    <PackageReference Include="Microsoft.Extensions.FileProviders.Physical" Version="3.0.0" />
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="3.1.18" />
+    <PackageReference Include="Microsoft.Extensions.FileProviders.Composite" Version="3.1.18" />
+    <PackageReference Include="Microsoft.Extensions.FileProviders.Physical" Version="3.1.18" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\..\core\Statiq.Common\Statiq.Common.csproj" />

--- a/tests/core/Statiq.Common.Tests/Statiq.Common.Tests.csproj
+++ b/tests/core/Statiq.Common.Tests/Statiq.Common.Tests.csproj
@@ -5,7 +5,7 @@
     <ProjectReference Include="..\..\..\src\core\Statiq.Testing\Statiq.Testing.csproj" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="3.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="3.1.18" />
   </ItemGroup>
   <ItemGroup>
     <Folder Include="Scripting\" />

--- a/tests/core/Statiq.Core.Tests/Statiq.Core.Tests.csproj
+++ b/tests/core/Statiq.Core.Tests/Statiq.Core.Tests.csproj
@@ -5,6 +5,6 @@
     <ProjectReference Include="..\..\..\src\core\Statiq.Testing\Statiq.Testing.csproj" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="3.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="3.1.18" />
   </ItemGroup>
 </Project>


### PR DESCRIPTION
An audit came across a few outdated assemblies, focus this PR around Microsoft.Extensions.*

* Microsoft.Extensions.Configuration.Abstractions to 3.1.18
* Microsoft.Extensions.Configuration.CommandLine to 3.1.18
* Microsoft.Extensions.Configuration.EnvironmentVariables to 3.1.18
* Microsoft.Extensions.Configuration.Json to 3.1.18
* Microsoft.Extensions.Configuration.Xml to 3.1.18
* Microsoft.Extensions.DependencyInjection.Abstractions to 3.1.18
* Microsoft.Extensions.DependencyInjection to 3.1.18
* Microsoft.Extensions.DependencyModel to 3.1.6
* Microsoft.Extensions.FileProviders.Composite to 3.1.18
* Microsoft.Extensions.FileProviders.Physical to 3.1.18
* Microsoft.Extensions.FileSystemGlobbing to 3.1.18
* Microsoft.Extensions.Logging.Abstractions to 3.1.18
* Microsoft.Extensions.Logging.Debug to 3.1.18
* Microsoft.Extensions.Logging to 3.1.18