### PR TITLE
Switch from System to Microsoft SqlClient

### DIFF
--- a/src/core/Statiq.Core/Modules/Metadata/ReadSql.cs
+++ b/src/core/Statiq.Core/Modules/Metadata/ReadSql.cs
@@ -1,9 +1,9 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Data;
-using System.Data.SqlClient;
 using System.Linq;
 using System.Threading.Tasks;
+using Microsoft.Data.SqlClient;
 using Statiq.Common;
 
 namespace Statiq.Core

--- a/src/core/Statiq.Core/Statiq.Core.csproj
+++ b/src/core/Statiq.Core/Statiq.Core.csproj
@@ -13,7 +13,7 @@
     <PackageReference Include="Polly" Version="7.1.1" />
     <PackageReference Include="SemanticVersioning" Version="1.2.2" />
     <PackageReference Include="System.Collections.Immutable" Version="5.0.0" />
-    <PackageReference Include="System.Data.SqlClient" Version="4.4.3" />
+    <PackageReference Include="Microsoft.Data.SqlClient" Version="3.0.0" />
     <PackageReference Include="System.Linq.Async" Version="4.0.0" />
   </ItemGroup>
   <ItemGroup>


### PR DESCRIPTION
An audit came across usage of the System.Data.SqlClient, it's obsolete and has been replaced by Microsoft.Data.SqlClient.