### PR TITLE
Option to skip highlighting for unspecified language

### DIFF
--- a/src/extensions/Statiq.Highlight/HighlightCode.cs
+++ b/src/extensions/Statiq.Highlight/HighlightCode.cs
@@ -39,6 +39,7 @@ namespace Statiq.Highlight
         private string _codeQuerySelector = "pre code";
         private string _highlightJsFile;
         private bool _warnOnMissingLanguage = true;
+        private bool _autoHighlightUnspecifiedLanguage = true;
 
         /// <summary>
         /// Sets the query selector to use to find code blocks.
@@ -73,6 +74,17 @@ namespace Statiq.Highlight
             return this;
         }
 
+        /// <summary>
+        /// Sets whether auto highlighting is performed when there is no language specified on the code block.
+        /// </summary>
+        /// <param name="autoHighlight">if set to <c>true</c> [auto highlight unspecified language].</param>
+        /// <returns>The current instance.</returns>
+        public HighlightCode WithAutoHighlightUnspecifiedLanguage(bool autoHighlight)
+        {
+            _autoHighlightUnspecifiedLanguage = autoHighlight;
+            return this;
+        }
+
         /// <inheritdoc />
         protected override async Task<IEnumerable<IDocument>> ExecuteContextAsync(IExecutionContext context)
         {
@@ -102,6 +114,12 @@ namespace Statiq.Highlight
                                 {
                                     // Don't highlight anything that potentially is already highlighted
                                     if (element.ClassList.Contains("hljs"))
+                                    {
+                                        continue;
+                                    }
+
+                                    // Skip highlighting if there is no language detected and auto highlight is disabled for unspecified languages
+                                    if (!element.ClassList.Any(c => c.StartsWith("language")) && !_autoHighlightUnspecifiedLanguage)
                                     {
                                         continue;
                                     }

--- a/tests/extensions/Statiq.Highlight.Tests/HighlightCodeFixture.cs
+++ b/tests/extensions/Statiq.Highlight.Tests/HighlightCodeFixture.cs
@@ -255,6 +255,47 @@ namespace Statiq.Highlight.Tests
                 // Then
                 results.ShouldNotBeEmpty();
             }
+
+            [Test]
+            public async Task SkipHighlightingUnspecifiedLanguageCodeBlocksWhenConfigured()
+            {
+                // Given
+                const string input = @"
+<html>
+<head>
+    <title>Foobar</title>
+</head>
+<body>
+    <h1>Title</h1>
+    <p>This is some Foobar text</p>
+    <pre><code>
+    <html>
+    <head>
+    <title>Hi Mom!</title>
+    </head>
+    <body>
+        <p>Hello, world! Pretty me up!
+    </body>
+    </html>
+    </code></pre>
+</body>
+</html>";
+
+                TestDocument document = new TestDocument(input);
+                TestExecutionContext context = new TestExecutionContext()
+                {
+                    JsEngineFunc = () => new TestJsEngine()
+                };
+
+                HighlightCode highlight = new HighlightCode()
+                    .WithAutoHighlightUnspecifiedLanguage(false);
+
+                // When
+                TestDocument result = await ExecuteAsync(document, context, highlight).SingleAsync();
+
+                // Then
+                result.Content.ShouldNotContain("hljs");
+            }
         }
     }
 }


### PR DESCRIPTION
This relates to [my tweet](https://twitter.com/MrTurnerj/status/1452532459443134464) about highlighting without specifying a language takes a long time. Turns out that sometimes you just want a code block (in my case, from Markdown) and just don't need highlighting on it.

I first thought there might be a way to using a more complex CSS selector via `WithCodeQuerySelector` but I don't think we can really get that to work in this case.

Anyway, this follows the style of the other methods in the class and adds an option to skip auto highlighting if there is no language present. I do this in the method parent method as it has access to the instance and thus the new instance field (the other method is static and seemed unnecessary to change that).

I don't think I've missed anything in the Contributing guidelines but let me know if I have. Also I'm not 100% sure on the names of the field/method I've given as it seems a little wordy. I did think I could call it `skipOnMissingLanguage` but "missing language" here is that there is no language specified, not that Highlight.js doesn't have the required language unlike the other field.