### PR TITLE
Optimizing Replace method in MemoryExtensions

### DIFF
--- a/src/core/Statiq.Common/Util/MemoryExtensions.cs
+++ b/src/core/Statiq.Common/Util/MemoryExtensions.cs
@@ -42,11 +42,12 @@ namespace Statiq.Common
             char newChar)
         {
             bool replaced = false;
+            Span<char> span = str.Span;
             for (int c = 0; c < str.Length; c++)
             {
-                if (str.Span[c] == oldChar)
+                if (span[c] == oldChar)
                 {
-                    str.Span[c] = newChar;
+                    span[c] = newChar;
                     replaced = true;
                 }
             }
@@ -59,11 +60,13 @@ namespace Statiq.Common
             char newChar)
         {
             bool replaced = false;
+            Span<char> span = str.Span;
             for (int c = 0; c < str.Length; c++)
             {
+                char currentChar = span[c];
                 foreach (char oldChar in oldChars)
                 {
-                    if (str.Span[c] == oldChar)
+                    if (currentChar == oldChar)
                     {
                         str.Span[c] = newChar;
                         replaced = true;


### PR DESCRIPTION
I was taking a look at some of the perf and poked around here. With 4,000 files the little things are starting to add up. Did two main things

* Convert to a span outside of the loop. This is actually a pretty cheap call, but with this many `NormalizedPath` being created it gets called a ton
* Pull the span outside of the loop to compare once. 

Took the number of times the call to the `Span` getter and the indexer were being called from 200 million times down to 5 million. This helps out a bit with the constructor knocking the total amount of time spent building those up on my machine from 18s down to 5. 

## Before
![image](https://user-images.githubusercontent.com/2447331/153738302-eb38d521-5435-4006-a057-f9c5aba732ca.png)

## After
![image](https://user-images.githubusercontent.com/2447331/153738293-8bb31732-b808-449b-9bcf-1fa5e5b38f3e.png)
