### PR TITLE
Remove build.cmd

### DIFF
--- a/build.cmd
+++ b/build.cmd
@@ -1,5 +1,0 @@
-@echo off
-dotnet run --project "build/Statiq.Framework.Build/Statiq.Framework.Build.csproj" -- %*
-set exitcode=%errorlevel%
-cd %~dp0
-exit /b %exitcode%


### PR DESCRIPTION
Remove build.cmd since it points to a no longer existent project and also is no longer mentioned in https://github.com/statiqdev/Statiq.Framework/blob/main/BUILDING.md