### PR TITLE
Bump version of SixLabors ImageSharp

### DIFF
--- a/src/extensions/Statiq.Images/Statiq.Images.csproj
+++ b/src/extensions/Statiq.Images/Statiq.Images.csproj
@@ -4,7 +4,7 @@
     <PackageTags>Statiq Static StaticContent StaticSite Blog BlogEngine Images ImageProcessor</PackageTags>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="SixLabors.ImageSharp" Version="1.0.1" />
+    <PackageReference Include="SixLabors.ImageSharp" Version="1.0.4" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\..\core\Statiq.Common\Statiq.Common.csproj" />


### PR DESCRIPTION
There are a couple of bugs related to https://github.com/SixLabors/ImageSharp/issues/1704 which I've been hitting running Statiq that surface on .Net 6. These look to have been resolved upstream, and attempting to run it locally with this change seems to be better.

Happy to raise an issue if that's a better way to discuss this, but I thought this was a light enough weight change.

- v1.01 to 1.0.4 has no breaking changes documented
- there's some test coverage of images working within Statiq, and ImageSharp has tests covering specifically this issue 
- there's a major version upgrade available as well, but that looked to need more changes/didn't feel like something I could do quickly/safely