### PR TITLE
Update JavaScriptEngineSwitcher Core&Jint to 3.19.0&3.1.0

### DIFF
--- a/src/core/Statiq.Core/Statiq.Core.csproj
+++ b/src/core/Statiq.Core/Statiq.Core.csproj
@@ -4,8 +4,8 @@
     <PackageTags>Statiq Static StaticContent StaticSite Blog BlogEngine</PackageTags>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="JavaScriptEngineSwitcher.Core" Version="3.0.0" />
-    <PackageReference Include="JavaScriptEngineSwitcher.Jint" Version="3.0.0" />
+    <PackageReference Include="JavaScriptEngineSwitcher.Core" Version="3.19.0" />
+    <PackageReference Include="JavaScriptEngineSwitcher.Jint" Version="3.1.0" />
     <PackageReference Include="JSPool" Version="2.0.1" />
     <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="4.1.0" />
     <PackageReference Include="Microsoft.Extensions.Logging" Version="3.1.18" />

--- a/src/core/Statiq.Testing.JavaScript/Statiq.Testing.JavaScript.csproj
+++ b/src/core/Statiq.Testing.JavaScript/Statiq.Testing.JavaScript.csproj
@@ -4,8 +4,8 @@
     <PackageTags>Statiq Static StaticContent StaticSite Blog BlogEngine</PackageTags>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="JavaScriptEngineSwitcher.Core" Version="3.0.0" />
-    <PackageReference Include="JavaScriptEngineSwitcher.Jint" Version="3.0.0" />
+    <PackageReference Include="JavaScriptEngineSwitcher.Core" Version="3.19.0" />
+    <PackageReference Include="JavaScriptEngineSwitcher.Jint" Version="3.1.0" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\Statiq.Common\Statiq.Common.csproj" />


### PR DESCRIPTION
I noticed a warning when compiling 
```diff
- Package JavaScriptEngineSwitcher.Core 3.0.0 has a resource with the locale 'ru-ru'.
- This locale has been normalized to the standard format 'ru-RU' to prevent casing issues in the build.
- Consider notifying the package author about this casing issue.
```
Looking at the 3.0.0 package
![image](https://user-images.githubusercontent.com/1647294/199696161-f32d6f8a-faff-43c2-b406-35daec8bb496.png)
vs. 3.19.0
![image](https://user-images.githubusercontent.com/1647294/199696229-6ecc1d56-85b4-48a1-bf46-98096ee54ee3.png)
it's now been fixed.
