### PR TITLE
Migrate to Spectre.Console.Cli

### DIFF
--- a/src/core/Statiq.App/Statiq.App.csproj
+++ b/src/core/Statiq.App/Statiq.App.csproj
@@ -21,7 +21,8 @@
     <PackageReference Include="Microsoft.Extensions.Logging.Debug" Version="3.1.18" />
     <PackageReference Include="NetEscapades.Configuration.Yaml" Version="2.0.1" />
     <PackageReference Include="NetEscapades.Extensions.Logging.RollingFile" Version="2.2.0" />
-    <PackageReference Include="Spectre.Console" Version="0.43.0" />
+    <PackageReference Include="Spectre.Console" Version="0.45.0" />
+    <PackageReference Include="Spectre.Console.Cli" Version="0.45.0" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
Spectre.Console 0.45.0 all Cli functionality was removed and placed in its own Spectre.Console.Cli package this PR
* Updates Spectre.Console to 0.45.0
* Adds Spectre.Console.Cli 0.45.0