### PR TITLE
Bump YamlDotNet Package which is Deprecated

### DIFF
--- a/src/extensions/Statiq.Yaml/Statiq.Yaml.csproj
+++ b/src/extensions/Statiq.Yaml/Statiq.Yaml.csproj
@@ -4,7 +4,7 @@
     <PackageTags>Statiq Static StaticContent StaticSite Blog BlogEngine Yaml</PackageTags>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="YamlDotNet" Version="4.3.1" />
+    <PackageReference Include="YamlDotNet" Version="13.0.0" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\..\core\Statiq.Common\Statiq.Common.csproj" />


### PR DESCRIPTION
I've had YamlDotNet already loaded in my project, reading front matter for markdown however threw System.MissingMethodException: Method not found: 
System.Collections.Generic.IDictionary`2<YamlDotNet.RepresentationModel.YamlNode,YamlDotNet.RepresentationModel.YamlNode> YamlDotNet.RepresentationModel.YamlMappingNode.get_Children()

Package generally had been deprecated so updating to the latest version.