### PR TITLE
Upgrade to .NET 8

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -19,11 +19,11 @@ jobs:
       NUGET_CERT_REVOCATION_MODE: offline
     steps:
       - name: Get Source
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
         with:
           submodules: recursive
       - name: Install .NET Core SDK
-        uses: actions/setup-dotnet@v1
+        uses: actions/setup-dotnet@v4
         with:
           dotnet-version: |
             3.1.x

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -32,7 +32,7 @@ jobs:
       - name: Build and Test
         run: dotnet test --logger "trx;LogFileName=test-results.trx"
       - name: Upload Test Results
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v3 # Stick with v3 until https://github.com/dorny/test-reporter/issues/343 is resolved
         if: success() || failure()
         with:
           name: test-results-${{ matrix.os }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -28,12 +28,11 @@ jobs:
         uses: actions/setup-dotnet@v4
         with:
           dotnet-version: |
-            3.1.x
-            6.0.x
+            8.x
       - name: Build and Test
         run: dotnet test --logger "trx;LogFileName=test-results.trx"
       - name: Upload Test Results
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v4
         if: success() || failure()
         with:
           name: test-results-${{ matrix.os }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -5,6 +5,8 @@ on:
   push:
     branches:
       - main
+      - net80incremental
+
 jobs:
   build:
     name: Build
@@ -35,4 +37,4 @@ jobs:
         if: success() || failure()
         with:
           name: test-results-${{ matrix.os }}
-          path: '**/test-results.trx'
+          path: "**/test-results.trx"

--- a/.github/workflows/test-report.yml
+++ b/.github/workflows/test-report.yml
@@ -13,7 +13,7 @@ jobs:
         os: [windows-latest, ubuntu-latest, macos-latest]
     steps:
       - name: Process Test Results
-        uses: dorny/test-reporter@v1
+        uses: dorny/test-reporter@v1.7.0
         with:
           artifact: test-results-${{ matrix.os }}
           name: 'Test Results (${{ matrix.os }})'

--- a/.github/workflows/test-report.yml
+++ b/.github/workflows/test-report.yml
@@ -1,7 +1,7 @@
-name: 'Test Report'
+name: "Test Report"
 on:
   workflow_run:
-    workflows: [ 'Build' ]
+    workflows: ["Build"]
     types:
       - completed
 jobs:
@@ -16,6 +16,6 @@ jobs:
         uses: dorny/test-reporter@v1.7.0
         with:
           artifact: test-results-${{ matrix.os }}
-          name: 'Test Results (${{ matrix.os }})'
-          path: '**/*.trx'
+          name: "Test Results (${{ matrix.os }})"
+          path: "**/*.trx"
           reporter: dotnet-trx

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -20,16 +20,16 @@
     <IncludeSymbols>true</IncludeSymbols>
     <SymbolPackageFormat>snupkg</SymbolPackageFormat>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <EmbedUntrackedSources>true</EmbedUntrackedSources>
-    <WarningsNotAsErrors>NU1901;NU1902;NU1903;NU1904;CA1724</WarningsNotAsErrors>
+    <WarningsNotAsErrors>NU1901;NU1902;NU1903;NU1904;CA1040;CA1724;CA1062;CA1710;CA1711;CA1725;CS8600;CS8601;CS8602;CS8603;CS8604;CS8618;CS8619;CS8620;CS8622;CS8625;CS8631</WarningsNotAsErrors>
   </PropertyGroup>
   <ItemGroup>
     <None Include="$(MSBuildThisFileDirectory)\LICENSE.md" Pack="true" PackagePath=""/>
     <None Include="$(MSBuildThisFileDirectory)\icon.png" Pack="true" PackagePath="\"/>
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.1.1" PrivateAssets="All"/>
+    <PackageReference Include="Microsoft.SourceLink.GitHub" Version="8.0.0" PrivateAssets="All"/>
     <PackageReference Include="StyleCop.Analyzers" Version="1.1.118" PrivateAssets="All"/>
     <PackageReference Include="Roslynator.Analyzers" Version="4.0.2" PrivateAssets="All"/>
     <!-- It appears as though there might be a performance issue in versions of Microsoft.VisualStudio.Threading.Analyzers past this at least through 17.0.64 -->

--- a/src/core/Statiq.App/Commands/PipelinesCommand{TSettings}.cs
+++ b/src/core/Statiq.App/Commands/PipelinesCommand{TSettings}.cs
@@ -38,7 +38,9 @@ namespace Statiq.App
             {
                 new ConsoleListener(() =>
                 {
+#pragma warning disable VSTHRD103
                     cancellationTokenSource.Cancel();
+#pragma warning restore VSTHRD103
                     return Task.CompletedTask;
                 });
                 return (int)await engineManager.ExecuteAsync(cancellationTokenSource);

--- a/src/core/Statiq.App/Statiq.App.csproj
+++ b/src/core/Statiq.App/Statiq.App.csproj
@@ -11,7 +11,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Scripting" Version="4.8.0" />
+    <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Scripting" Version="4.4.0" />
     <PackageReference Include="Microsoft.Extensions.Configuration.CommandLine" Version="8.0.0" />
     <PackageReference Include="Microsoft.Extensions.Configuration.EnvironmentVariables" Version="8.0.0" />
     <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="8.0.0" />

--- a/src/core/Statiq.App/Statiq.App.csproj
+++ b/src/core/Statiq.App/Statiq.App.csproj
@@ -11,14 +11,14 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Scripting" Version="4.1.0" />
-    <PackageReference Include="Microsoft.Extensions.Configuration.CommandLine" Version="3.1.18" />
-    <PackageReference Include="Microsoft.Extensions.Configuration.EnvironmentVariables" Version="3.1.18" />
-    <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="3.1.18" />
-    <PackageReference Include="Microsoft.Extensions.Configuration.Xml" Version="3.1.18" />
-    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="3.1.18" />
-    <PackageReference Include="Microsoft.Extensions.Logging" Version="3.1.18" />
-    <PackageReference Include="Microsoft.Extensions.Logging.Debug" Version="3.1.18" />
+    <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Scripting" Version="4.8.0" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.CommandLine" Version="8.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.EnvironmentVariables" Version="8.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="8.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.Xml" Version="8.0.0" />
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="8.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Logging" Version="8.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Debug" Version="8.0.0" />
     <PackageReference Include="NetEscapades.Configuration.Yaml" Version="3.1.0" />
     <PackageReference Include="NetEscapades.Extensions.Logging.RollingFile" Version="2.2.0" />
     <PackageReference Include="Spectre.Console" Version="0.45.0" />

--- a/src/core/Statiq.Common/Content/MediaTypes.cs
+++ b/src/core/Statiq.Common/Content/MediaTypes.cs
@@ -1086,7 +1086,9 @@ namespace Statiq.Common
         /// <param name="mediaType">The media type.</param>
         /// <param name="defaultIfNotFound">Will return a "text/x-[extension]" default media type if a mapping is not found.</param>
         /// <returns><c>true</c> if the media type could be determined, <c>false</c> otherwise.</returns>
+#pragma warning disable CA1021 // Avoid out parameters
         public static bool TryGet(string path, out string mediaType, bool defaultIfNotFound = true)
+#pragma warning restore CA1021 // Avoid out parameters
         {
             if (string.IsNullOrWhiteSpace(path))
             {

--- a/src/core/Statiq.Common/Documents/ObjectDocument{T}.cs
+++ b/src/core/Statiq.Common/Documents/ObjectDocument{T}.cs
@@ -30,7 +30,9 @@ namespace Statiq.Common
         /// <summary>
         /// The underlying object.
         /// </summary>
+#pragma warning disable CA1720 // Identifier contains type name
         public T Object { get; }
+#pragma warning restore CA1720 // Identifier contains type name
 
         /// <inheritdoc />
         public NormalizedPath Source { get; }

--- a/src/core/Statiq.Common/IO/IReadOnlyFileSystemExtensions.cs
+++ b/src/core/Statiq.Common/IO/IReadOnlyFileSystemExtensions.cs
@@ -21,10 +21,12 @@ namespace Statiq.Common
         /// path is deeper than the real one). This contains all the mapped input paths that couldn't be unmapped.
         /// </param>
         /// <returns>The "unmapped" input paths.</returns>
+#pragma warning disable CA1021
         public static IEnumerable<NormalizedPath> GetUnmappedInputPaths(
             this IReadOnlyFileSystem fileSystem,
             in NormalizedPath path,
             out HashSet<NormalizedPath> nonExistingMappedPaths)
+#pragma warning restore CA1021
         {
             fileSystem.ThrowIfNull(nameof(fileSystem));
             path.ThrowIfNull(nameof(path));

--- a/src/core/Statiq.Common/Scripting/IScriptHelper.cs
+++ b/src/core/Statiq.Common/Scripting/IScriptHelper.cs
@@ -46,7 +46,9 @@ namespace Statiq.Common
         /// <c>true</c> if the candidate string is a script string that should be cached,
         /// <c>false</c> if the candidate string is a script string that should not be cached,
         /// and null otherwise.</returns>
+#pragma warning disable CA1021
         public static bool? TryGetScriptString(string str, out string script)
+#pragma warning restore CA1021
         {
             if (TryGetScriptString(str, true, out script))
             {

--- a/src/core/Statiq.Common/Statiq.Common.csproj
+++ b/src/core/Statiq.Common/Statiq.Common.csproj
@@ -4,7 +4,7 @@
     <PackageTags>Statiq Static StaticContent StaticSite Blog BlogEngine</PackageTags>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="AngleSharp" Version="0.16.1" />
+    <PackageReference Include="AngleSharp" Version="1.0.7" />
     <PackageReference Include="ConcurrentHashSet" Version="1.1.0" />
     <PackageReference Include="Microsoft.Extensions.Configuration.Abstractions" Version="8.0.0" />
     <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="8.0.0" />

--- a/src/core/Statiq.Common/Statiq.Common.csproj
+++ b/src/core/Statiq.Common/Statiq.Common.csproj
@@ -5,7 +5,7 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="AngleSharp" Version="1.0.7" />
-    <PackageReference Include="ConcurrentHashSet" Version="1.1.0" />
+    <PackageReference Include="ConcurrentHashSet" Version="1.3.0" />
     <PackageReference Include="Microsoft.Extensions.Configuration.Abstractions" Version="8.0.0" />
     <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="8.0.0" />
     <PackageReference Include="Microsoft.Extensions.DependencyModel" Version="8.0.0" />

--- a/src/core/Statiq.Common/Statiq.Common.csproj
+++ b/src/core/Statiq.Common/Statiq.Common.csproj
@@ -6,11 +6,11 @@
   <ItemGroup>
     <PackageReference Include="AngleSharp" Version="0.16.1" />
     <PackageReference Include="ConcurrentHashSet" Version="1.1.0" />
-    <PackageReference Include="Microsoft.Extensions.Configuration.Abstractions" Version="3.1.18" />
-    <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="3.1.18" />
-    <PackageReference Include="Microsoft.Extensions.DependencyModel" Version="3.1.6" />
-    <PackageReference Include="Microsoft.Extensions.FileSystemGlobbing" Version="3.1.18" />
-    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="3.1.18" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.Abstractions" Version="8.0.0" />
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="8.0.0" />
+    <PackageReference Include="Microsoft.Extensions.DependencyModel" Version="8.0.0" />
+    <PackageReference Include="Microsoft.Extensions.FileSystemGlobbing" Version="8.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="8.0.0" />
     <PackageReference Include="NetFabric.Hyperlinq" Version="3.0.0-beta48" />
   </ItemGroup>
   <ItemGroup>

--- a/src/core/Statiq.Common/Util/ItemStreams/ItemStream{TItem}.cs
+++ b/src/core/Statiq.Common/Util/ItemStreams/ItemStream{TItem}.cs
@@ -196,7 +196,9 @@ namespace Statiq.Common
 
         public sealed override int WriteTimeout { get => base.WriteTimeout; set => base.WriteTimeout = value; }
 
+#pragma warning disable CS0672,SYSLIB0010 // Member overrides obsolete member
         public sealed override object InitializeLifetimeService() => base.InitializeLifetimeService();
+#pragma warning restore CS0672,SYSLIB0010 // Member overrides obsolete member
 
         public sealed override IAsyncResult BeginRead(byte[] buffer, int offset, int count, AsyncCallback callback, object state) => base.BeginRead(buffer, offset, count, callback, state);
 

--- a/src/core/Statiq.Common/Util/LockingStreamWrapper.cs
+++ b/src/core/Statiq.Common/Util/LockingStreamWrapper.cs
@@ -23,7 +23,9 @@ namespace Statiq.Common
             _disposeStream = disposeStream;
         }
 
+#pragma warning disable CA1721
         protected Stream Stream { get; }
+#pragma warning restore CA1721
 
         /// <summary>
         /// Gets the wrapped stream and locks access until it's disposed.

--- a/src/core/Statiq.Common/Util/StringStream.cs
+++ b/src/core/Statiq.Common/Util/StringStream.cs
@@ -46,7 +46,9 @@ namespace Statiq.Common
             }
         }
 
+#pragma warning disable CA1720 // Identifier contains type name
         public string String { get; }
+#pragma warning restore CA1720 // Identifier contains type name
 
         public override bool CanRead => true;
 

--- a/src/core/Statiq.Core/Execution/ExecutionPipeline.cs
+++ b/src/core/Statiq.Core/Execution/ExecutionPipeline.cs
@@ -79,7 +79,7 @@ namespace Statiq.Core
         public virtual ExecutionPolicy ExecutionPolicy { get; set; }
 
         protected sealed override Task<IEnumerable<IDocument>> ExecuteContextAsync(IExecutionContext context) =>
-            context.Phase switch
+            (context ?? throw new ArgumentNullException(nameof(context))).Phase switch
             {
                 Phase.Input => ExecuteInputPhaseAsync(context),
                 Phase.Process => ExecuteProcessPhaseAsync(context),

--- a/src/core/Statiq.Core/Execution/IEngineExtensions.cs
+++ b/src/core/Statiq.Core/Execution/IEngineExtensions.cs
@@ -18,16 +18,16 @@ namespace Statiq.Core
             // Get and print the version
             string informationalVersion = versionAttribute.InformationalVersion;
             engine.Logger.LogInformation($"{name} version {informationalVersion}", true);
-            SemVer.Version version = new SemVer.Version(informationalVersion, true);
+            SemanticVersioning.Version version = new SemanticVersioning.Version(informationalVersion, true);
 
             // Get all version ranges
-            (string Key, SemVer.Version Version)[] minimumVersions = engine.Settings.Keys
+            (string Key, SemanticVersioning.Version Version)[] minimumVersions = engine.Settings.Keys
                 .Where(k => k.StartsWith(minimumVersionKey))
                 .Select(k => (Key: k, Value: engine.Settings.GetString(k)))
                 .Where(x => !x.Value.IsNullOrWhiteSpace())
-                .Select(x => (x.Key, new SemVer.Version(x.Value, true)))
+                .Select(x => (x.Key, new SemanticVersioning.Version(x.Value, true)))
                 .ToArray();
-            foreach ((string Key, SemVer.Version Version) minimumVersion in minimumVersions)
+            foreach ((string Key, SemanticVersioning.Version Version) minimumVersion in minimumVersions)
             {
                 if (version < minimumVersion.Version)
                 {

--- a/src/core/Statiq.Core/Execution/IEngineExtensions.cs
+++ b/src/core/Statiq.Core/Execution/IEngineExtensions.cs
@@ -2,6 +2,7 @@
 using System.Linq;
 using System.Reflection;
 using Microsoft.Extensions.Logging;
+using Polly;
 using Statiq.Common;
 
 namespace Statiq.Core
@@ -10,6 +11,9 @@ namespace Statiq.Core
     {
         public static void LogAndCheckVersion(this IEngine engine, Assembly assembly, string name, string minimumVersionKey)
         {
+            ArgumentNullException.ThrowIfNull(assembly);
+            ArgumentNullException.ThrowIfNull(engine);
+
             if (!(Attribute.GetCustomAttribute(assembly, typeof(AssemblyInformationalVersionAttribute)) is AssemblyInformationalVersionAttribute versionAttribute))
             {
                 throw new Exception($"Could not determine the {name} version from {assembly.FullName}");

--- a/src/core/Statiq.Core/Execution/MemoryStreamFactory.cs
+++ b/src/core/Statiq.Core/Execution/MemoryStreamFactory.cs
@@ -14,13 +14,14 @@ namespace Statiq.Core
         private const int BlockSize = 16384;
 
         private readonly RecyclableMemoryStreamManager _manager =
-            new RecyclableMemoryStreamManager(
+#pragma warning disable SA1000
+            new(new RecyclableMemoryStreamManager.Options(
+#pragma warning restore SA1000
                 BlockSize,
                 RecyclableMemoryStreamManager.DefaultLargeBufferMultiple,
-                RecyclableMemoryStreamManager.DefaultMaximumBufferSize)
-            {
-                MaximumFreeSmallPoolBytes = BlockSize * 32768L * 2, // 1 GB
-            };
+                RecyclableMemoryStreamManager.DefaultMaximumBufferSize,
+                BlockSize * 32768L * 2, // 1 GB
+                0));
 
         public virtual MemoryStream GetStream() => _manager.GetStream();
 

--- a/src/core/Statiq.Core/Execution/NamespaceCollection.cs
+++ b/src/core/Statiq.Core/Execution/NamespaceCollection.cs
@@ -1,8 +1,10 @@
-﻿using System.Collections;
+﻿using System;
+using System.Collections;
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
 using ConcurrentCollections;
+using Polly;
 using Statiq.Common;
 
 namespace Statiq.Core
@@ -40,6 +42,8 @@ namespace Statiq.Core
 
         public virtual void AddRange(IEnumerable<string> namespaces)
         {
+            ArgumentNullException.ThrowIfNull(namespaces);
+
             // Iterate manually so we can throw for null or white space
             foreach (string ns in namespaces)
             {

--- a/src/core/Statiq.Core/Modules/Content/AddContentToMetadata.cs
+++ b/src/core/Statiq.Core/Modules/Content/AddContentToMetadata.cs
@@ -48,6 +48,8 @@ namespace Statiq.Core
             IExecutionContext context,
             ImmutableArray<IDocument> childOutputs)
         {
+            ArgumentNullException.ThrowIfNull(context);
+
             if (childOutputs.Length == 0)
             {
                 return context.Inputs;

--- a/src/core/Statiq.Core/Modules/Content/AddRtlSupport.cs
+++ b/src/core/Statiq.Core/Modules/Content/AddRtlSupport.cs
@@ -173,7 +173,9 @@ namespace Statiq.Core
                    c == 0x00FB3E;
         }
 
+#pragma warning disable CA1505 // Avoid unmaintainable code
         private static bool IsLeftToRight(int c)
+#pragma warning restore CA1505 // Avoid unmaintainable code
         {
             // Generated from Table D.2 of RFC3454
             // http://www.ietf.org/rfc/rfc3454.txt

--- a/src/core/Statiq.Core/Modules/Content/EscapeHtml.cs
+++ b/src/core/Statiq.Core/Modules/Content/EscapeHtml.cs
@@ -1,6 +1,8 @@
-﻿using System.Collections.Generic;
+﻿using System;
+using System.Collections.Generic;
 using System.IO;
 using System.Threading.Tasks;
+using Polly;
 using Statiq.Common;
 
 namespace Statiq.Core
@@ -159,6 +161,8 @@ namespace Statiq.Core
         /// <returns>The current module instance.</returns>
         public EscapeHtml WithStandard(params char[] standard)
         {
+            ArgumentNullException.ThrowIfNull(standard);
+
             foreach (char c in standard)
             {
                 _standardCharacters.Add(c);
@@ -185,6 +189,8 @@ namespace Statiq.Core
         /// <returns>The current module instance.</returns>
         public EscapeHtml WithEscapedChar(params char[] toEscape)
         {
+            ArgumentNullException.ThrowIfNull(toEscape);
+
             foreach (char c in toEscape)
             {
                 _currentlyEscapedCharacters.Add(
@@ -201,6 +207,8 @@ namespace Statiq.Core
 
         protected override async Task<IEnumerable<IDocument>> ExecuteInputAsync(IDocument input, IExecutionContext context)
         {
+            ArgumentNullException.ThrowIfNull(input);
+
             string oldContent = await input.GetContentStringAsync();
             StringWriter outputString = new StringWriter();
             bool escaped = false;

--- a/src/core/Statiq.Core/Modules/Content/GenerateRedirects.cs
+++ b/src/core/Statiq.Core/Modules/Content/GenerateRedirects.cs
@@ -148,6 +148,8 @@ namespace Statiq.Core
         /// <inheritdoc />
         protected override async Task<IEnumerable<IDocument>> ExecuteContextAsync(IExecutionContext context)
         {
+            ArgumentNullException.ThrowIfNull(context);
+
             // Iterate redirects and generate all of the per-redirect documents (I.e., meta refresh pages)
             ConcurrentDictionary<NormalizedPath, string> redirects = new ConcurrentDictionary<NormalizedPath, string>();
 

--- a/src/core/Statiq.Core/Modules/Content/GenerateSitemap.cs
+++ b/src/core/Statiq.Core/Modules/Content/GenerateSitemap.cs
@@ -77,6 +77,8 @@ namespace Statiq.Core
         /// <inheritdoc />
         protected override async Task<IEnumerable<IDocument>> ExecuteContextAsync(IExecutionContext context)
         {
+            ArgumentNullException.ThrowIfNull(context);
+
             HashSet<string> locations = new HashSet<string>(); // Remove duplicate locations
             List<string> content = new List<string>();
             content.Add("<?xml version=\"1.0\" encoding=\"UTF-8\"?><urlset xmlns=\"http://www.sitemaps.org/schemas/sitemap/0.9\">");

--- a/src/core/Statiq.Core/Modules/Content/InsertLinks.cs
+++ b/src/core/Statiq.Core/Modules/Content/InsertLinks.cs
@@ -150,7 +150,7 @@ namespace Statiq.Core
                 foreach (IElement element in htmlDocument.QuerySelectorAll(_querySelector).Where(t => !t.Ancestors<IHtmlAnchorElement>().Any()))
                 {
                     // Enumerate all descendant text nodes not already in a link element
-                    foreach (IText text in element.Descendents().OfType<IText>().Where(t => !t.Ancestors<IHtmlAnchorElement>().Any()))
+                    foreach (IText text in element.Descendants().OfType<IText>().Where(t => !t.Ancestors<IHtmlAnchorElement>().Any()))
                     {
                         if (ReplaceStrings(text, links, out string newText))
                         {

--- a/src/core/Statiq.Core/Modules/Content/JoinDocuments.cs
+++ b/src/core/Statiq.Core/Modules/Content/JoinDocuments.cs
@@ -53,6 +53,8 @@ namespace Statiq.Core
         /// <returns>A single document in a list.</returns>
         protected override async Task<IEnumerable<IDocument>> ExecuteContextAsync(IExecutionContext context)
         {
+            ArgumentNullException.ThrowIfNull(context);
+
             if (context.Inputs.Length < 1)
             {
                 return context.CreateDocument().Yield();

--- a/src/core/Statiq.Core/Modules/Content/MergeContent.cs
+++ b/src/core/Statiq.Core/Modules/Content/MergeContent.cs
@@ -59,6 +59,6 @@ namespace Statiq.Core
             ImmutableArray<IDocument> childOutputs) =>
             _reverse
                 ? childOutputs.SelectMany(childOutput => context.Inputs.Select(input => childOutput.Clone(input.ContentProvider)))
-                : context.Inputs.SelectMany(input => childOutputs.Select(result => input.Clone(result.ContentProvider)));
+                : (context ?? throw new ArgumentNullException(nameof(context))).Inputs.SelectMany(input => childOutputs.Select(result => input.Clone(result.ContentProvider)));
     }
 }

--- a/src/core/Statiq.Core/Modules/Content/ProcessShortcodes.cs
+++ b/src/core/Statiq.Core/Modules/Content/ProcessShortcodes.cs
@@ -50,6 +50,9 @@ namespace Statiq.Core
 
         protected override async Task<IEnumerable<IDocument>> ExecuteInputAsync(IDocument input, IExecutionContext context)
         {
+            ArgumentNullException.ThrowIfNull(input);
+            ArgumentNullException.ThrowIfNull(context);
+
             IContentProvider contentProvider = await ProcessShortcodesAsync(input, input.ContentProvider, context);
             return contentProvider is null ? input.Yield() : input.Clone(contentProvider).Yield();
         }

--- a/src/core/Statiq.Core/Modules/Content/ReplaceInContent.cs
+++ b/src/core/Statiq.Core/Modules/Content/ReplaceInContent.cs
@@ -76,6 +76,8 @@ namespace Statiq.Core
         /// <inheritdoc />
         protected override async Task<IEnumerable<IDocument>> ExecuteConfigAsync(IDocument input, IExecutionContext context, string value)
         {
+            ArgumentNullException.ThrowIfNull(input);
+
             if (value is null)
             {
                 value = string.Empty;

--- a/src/core/Statiq.Core/Modules/Content/ReplaceWithContent.cs
+++ b/src/core/Statiq.Core/Modules/Content/ReplaceWithContent.cs
@@ -1,4 +1,5 @@
-﻿using System.Collections.Generic;
+﻿using System;
+using System.Collections.Generic;
 using System.Text.RegularExpressions;
 using System.Threading.Tasks;
 using Statiq.Common;
@@ -49,6 +50,8 @@ namespace Statiq.Core
         /// <inheritdoc />
         protected override async Task<IEnumerable<IDocument>> ExecuteConfigAsync(IDocument input, IExecutionContext context, string value)
         {
+            ArgumentNullException.ThrowIfNull(input);
+
             if (value is null)
             {
                 value = string.Empty;

--- a/src/core/Statiq.Core/Modules/Content/SetMediaType.cs
+++ b/src/core/Statiq.Core/Modules/Content/SetMediaType.cs
@@ -18,6 +18,6 @@ namespace Statiq.Core
         }
 
         protected override IEnumerable<IDocument> ExecuteConfig(IDocument input, IExecutionContext context, string value) =>
-            input.MediaTypeEquals(value) ? input.Yield() : input.Clone(input.ContentProvider.CloneWithMediaType(value)).Yield();
+            (input ?? throw new ArgumentNullException(nameof(input))).MediaTypeEquals(value) ? input.Yield() : input.Clone(input.ContentProvider.CloneWithMediaType(value)).Yield();
     }
 }

--- a/src/core/Statiq.Core/Modules/Control/CacheDocuments.cs
+++ b/src/core/Statiq.Core/Modules/Control/CacheDocuments.cs
@@ -134,6 +134,8 @@ namespace Statiq.Core
         /// <inheritdoc />
         protected override async Task<IEnumerable<IDocument>> ExecuteContextAsync(IExecutionContext context)
         {
+            ArgumentNullException.ThrowIfNull(context);
+
             // If we're disabling the cache, clear any existing entries and just execute children
             if (context.Settings.GetBool(Keys.DisableCache))
             {

--- a/src/core/Statiq.Core/Modules/Control/CombineDocuments.cs
+++ b/src/core/Statiq.Core/Modules/Control/CombineDocuments.cs
@@ -1,4 +1,5 @@
-﻿using System.Collections.Generic;
+﻿using System;
+using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
 using Statiq.Common;
@@ -21,6 +22,8 @@ namespace Statiq.Core
         /// <inheritdoc />
         protected override async Task<IEnumerable<IDocument>> ExecuteContextAsync(IExecutionContext context)
         {
+            ArgumentNullException.ThrowIfNull(context);
+
             IDocument result = null;
             foreach (IDocument input in context.Inputs)
             {

--- a/src/core/Statiq.Core/Modules/Control/ConcatDocuments.cs
+++ b/src/core/Statiq.Core/Modules/Control/ConcatDocuments.cs
@@ -40,6 +40,6 @@ namespace Statiq.Core
         protected override IEnumerable<IDocument> ExecuteChildren(
             IExecutionContext context,
             ImmutableArray<IDocument> childOutputs) =>
-            context.Inputs.Concat(childOutputs);
+            (context ?? throw new ArgumentNullException(nameof(context))).Inputs.Concat(childOutputs);
     }
 }

--- a/src/core/Statiq.Core/Modules/Control/EnumerateValues.cs
+++ b/src/core/Statiq.Core/Modules/Control/EnumerateValues.cs
@@ -79,6 +79,8 @@ namespace Statiq.Core
 
         protected override async Task<IEnumerable<IDocument>> ExecuteConfigAsync(IDocument input, IExecutionContext context, IEnumerable<object> value)
         {
+            ArgumentNullException.ThrowIfNull(context);
+
             // Return the input document(s) for empty values
             if (value is null)
             {

--- a/src/core/Statiq.Core/Modules/Control/ExecuteBranch.cs
+++ b/src/core/Statiq.Core/Modules/Control/ExecuteBranch.cs
@@ -36,6 +36,8 @@ namespace Statiq.Core
         /// <inheritdoc />
         protected override async Task<IEnumerable<IDocument>> ExecuteContextAsync(IExecutionContext context)
         {
+            ArgumentNullException.ThrowIfNull(context);
+
             List<IDocument> results = new List<IDocument>();
             foreach (IEnumerable<IModule> modules in _branches)
             {

--- a/src/core/Statiq.Core/Modules/Control/ExecuteDestinations.cs
+++ b/src/core/Statiq.Core/Modules/Control/ExecuteDestinations.cs
@@ -60,7 +60,9 @@ namespace Statiq.Core
         /// Adds a module to execute. This method is mainly to support collection initialization.
         /// </summary>
         /// <param name="module">The module to add.</param>
+#pragma warning disable CA1725 // Parameter names should match base declaration
         public void Add(IModule module) => _modules.Add(module);
+#pragma warning restore CA1725 // Parameter names should match base declaration
 
         public ExecuteDestinations WithModules(params IModule[] modules)
         {
@@ -87,6 +89,8 @@ namespace Statiq.Core
 
         protected override async Task<IEnumerable<IDocument>> ExecuteConfigAsync(IDocument input, IExecutionContext context, IEnumerable<string> value)
         {
+            ArgumentNullException.ThrowIfNull(context);
+
             List<IDocument> results = new List<IDocument>();
             HashSet<IDocument> matched = new HashSet<IDocument>(context.Inputs.FilterDestinations(value));
             if (matched.Count > 0)

--- a/src/core/Statiq.Core/Modules/Control/ExecuteIf.cs
+++ b/src/core/Statiq.Core/Modules/Control/ExecuteIf.cs
@@ -1,4 +1,5 @@
-﻿using System.Collections;
+﻿using System;
+using System.Collections;
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
@@ -210,6 +211,8 @@ namespace Statiq.Core
         /// <inheritdoc />
         protected override async Task<IEnumerable<IDocument>> ExecuteContextAsync(IExecutionContext context)
         {
+            ArgumentNullException.ThrowIfNull(context);
+
             List<IDocument> results = new List<IDocument>();
             IReadOnlyList<IDocument> documents = context.Inputs;
             bool hasExecuted = false;

--- a/src/core/Statiq.Core/Modules/Control/ExecuteModules.cs
+++ b/src/core/Statiq.Core/Modules/Control/ExecuteModules.cs
@@ -26,6 +26,6 @@ namespace Statiq.Core
         protected override IEnumerable<IDocument> ExecuteChildren(
             IExecutionContext context,
             ImmutableArray<IDocument> childOutputs) =>
-            context.Inputs;
+            (context ?? throw new ArgumentNullException(nameof(context))).Inputs;
     }
 }

--- a/src/core/Statiq.Core/Modules/Control/ExecuteSources.cs
+++ b/src/core/Statiq.Core/Modules/Control/ExecuteSources.cs
@@ -60,7 +60,9 @@ namespace Statiq.Core
         /// Adds a module to execute. This method is mainly to support collection initialization.
         /// </summary>
         /// <param name="module">The module to add.</param>
+#pragma warning disable CA1725 // Parameter names should match base declaration
         public void Add(IModule module) => _modules.Add(module);
+#pragma warning restore CA1725 // Parameter names should match base declaration
 
         public ExecuteSources WithModules(params IModule[] modules)
         {
@@ -87,6 +89,8 @@ namespace Statiq.Core
 
         protected override async Task<IEnumerable<IDocument>> ExecuteConfigAsync(IDocument input, IExecutionContext context, IEnumerable<string> value)
         {
+            ArgumentNullException.ThrowIfNull(context);
+
             List<IDocument> results = new List<IDocument>();
             HashSet<IDocument> matched = new HashSet<IDocument>(context.Inputs.FilterSources(value));
             if (matched.Count > 0)

--- a/src/core/Statiq.Core/Modules/Control/ExecuteSwitch.cs
+++ b/src/core/Statiq.Core/Modules/Control/ExecuteSwitch.cs
@@ -77,6 +77,8 @@ namespace Statiq.Core
         /// <inheritdoc />
         protected override async Task<IEnumerable<IDocument>> ExecuteContextAsync(IExecutionContext context)
         {
+            ArgumentNullException.ThrowIfNull(context);
+
             List<IDocument> results = new List<IDocument>();
             IEnumerable<IDocument> documents = context.Inputs;
             foreach (Tuple<object, IEnumerable<IModule>> c in _cases)

--- a/src/core/Statiq.Core/Modules/Control/ExtractFrontMatter.cs
+++ b/src/core/Statiq.Core/Modules/Control/ExtractFrontMatter.cs
@@ -165,6 +165,8 @@ namespace Statiq.Core
         // Execute at the context level so we can compile the RegEx pattern(s) once.
         protected override async Task<IEnumerable<IDocument>> ExecuteContextAsync(IExecutionContext context)
         {
+            ArgumentNullException.ThrowIfNull(context);
+
             List<Regex> regexes = new List<Regex>();
 
             // Get the explicit delimiter regex

--- a/src/core/Statiq.Core/Modules/Control/FilterDestinations.cs
+++ b/src/core/Statiq.Core/Modules/Control/FilterDestinations.cs
@@ -57,6 +57,6 @@ namespace Statiq.Core
             IDocument input,
             IExecutionContext context,
             IEnumerable<string> value) =>
-            context.Inputs.FilterDestinations(value);
+            (context ?? throw new ArgumentNullException(nameof(context))).Inputs.FilterDestinations(value);
     }
 }

--- a/src/core/Statiq.Core/Modules/Control/FilterDocuments.cs
+++ b/src/core/Statiq.Core/Modules/Control/FilterDocuments.cs
@@ -65,7 +65,11 @@ namespace Statiq.Core
         public FilterDocuments Or(string key) => Or(Config.FromDocument(doc => doc.ContainsKey(key)));
 
         /// <inheritdoc />
-        protected override async Task<IEnumerable<IDocument>> ExecuteContextAsync(IExecutionContext context) =>
-            await context.Inputs.FilterAsync(_predicates, context).ToListAsync(context.CancellationToken);
+        protected override async Task<IEnumerable<IDocument>> ExecuteContextAsync(IExecutionContext context)
+        {
+            ArgumentNullException.ThrowIfNull(context);
+
+            return await context.Inputs.FilterAsync(_predicates, context).ToListAsync(context.CancellationToken);
+        }
     }
 }

--- a/src/core/Statiq.Core/Modules/Control/FilterSources.cs
+++ b/src/core/Statiq.Core/Modules/Control/FilterSources.cs
@@ -57,6 +57,6 @@ namespace Statiq.Core
             IDocument input,
             IExecutionContext context,
             IEnumerable<string> value) =>
-            context.Inputs.FilterSources(value);
+            (context ?? throw new ArgumentNullException(nameof(context))).Inputs.FilterSources(value);
     }
 }

--- a/src/core/Statiq.Core/Modules/Control/GroupDocuments.cs
+++ b/src/core/Statiq.Core/Modules/Control/GroupDocuments.cs
@@ -91,6 +91,8 @@ namespace Statiq.Core
         /// <inheritdoc />
         protected override async Task<IEnumerable<IDocument>> ExecuteContextAsync(IExecutionContext context)
         {
+            ArgumentNullException.ThrowIfNull(context);
+
             List<(IDocument Document, IEnumerable<object> Keys)> groups = await context.Inputs
                 .ToAsyncEnumerable()
                 .SelectAwait(async x => (Document: x, Keys: await _key.GetValueAsync(x, context)))

--- a/src/core/Statiq.Core/Modules/Control/MergeDocuments.cs
+++ b/src/core/Statiq.Core/Modules/Control/MergeDocuments.cs
@@ -70,19 +70,31 @@ namespace Statiq.Core
 
         protected override IEnumerable<IDocument> ExecuteChildren(
             IExecutionContext context,
-            ImmutableArray<IDocument> childOutputs) =>
-            _reverse
+            ImmutableArray<IDocument> childOutputs)
+        {
+            ArgumentNullException.ThrowIfNull(context);
+
+            return _reverse
                 ? childOutputs.SelectMany(childOutput =>
                 {
                     IMetadata childOutputWithoutSettings = childOutput.WithoutSettings();
                     return context.Inputs.Select(input =>
-                        childOutput.Clone(_keepExistingMetadata ? input.WithoutSettings().GetRawEnumerable().Where(x => !childOutputWithoutSettings.ContainsKey(x.Key)) : input, input.ContentProvider));
+                        childOutput.Clone(
+                            _keepExistingMetadata
+                                ? input.WithoutSettings().GetRawEnumerable()
+                                    .Where(x => !childOutputWithoutSettings.ContainsKey(x.Key))
+                                : input, input.ContentProvider));
                 })
                 : context.Inputs.SelectMany(input =>
                 {
                     IMetadata inputWithoutSettings = input.WithoutSettings();
                     return childOutputs.Select(result =>
-                        input.Clone(_keepExistingMetadata ? result.WithoutSettings().GetRawEnumerable().Where(x => !inputWithoutSettings.ContainsKey(x.Key)) : result, result.ContentProvider));
+                        input.Clone(
+                            _keepExistingMetadata
+                                ? result.WithoutSettings().GetRawEnumerable()
+                                    .Where(x => !inputWithoutSettings.ContainsKey(x.Key))
+                                : result, result.ContentProvider));
                 });
+        }
     }
 }

--- a/src/core/Statiq.Core/Modules/Control/OrderDocuments.cs
+++ b/src/core/Statiq.Core/Modules/Control/OrderDocuments.cs
@@ -149,6 +149,8 @@ namespace Statiq.Core
         /// <inheritdoc />
         protected override Task<IEnumerable<IDocument>> ExecuteContextAsync(IExecutionContext context)
         {
+            ArgumentNullException.ThrowIfNull(context);
+
             IOrderedEnumerable<IDocument> orderdList = null;
             foreach (Order order in _orders.Reverse())
             {

--- a/src/core/Statiq.Core/Modules/Control/PaginateDocuments.cs
+++ b/src/core/Statiq.Core/Modules/Control/PaginateDocuments.cs
@@ -86,6 +86,8 @@ namespace Statiq.Core
         /// <inheritdoc />
         protected override IEnumerable<IDocument> ExecuteContext(IExecutionContext context)
         {
+            ArgumentNullException.ThrowIfNull(context);
+
             // Partition the pages and get a total before skip/take
             IDocument[][] pages =
                 Partition(context.Inputs, _pageSize)

--- a/src/core/Statiq.Core/Modules/Control/ProcessSidecarFile.cs
+++ b/src/core/Statiq.Core/Modules/Control/ProcessSidecarFile.cs
@@ -64,6 +64,9 @@ namespace Statiq.Core
         /// <inheritdoc />
         protected override async Task<IEnumerable<IDocument>> ExecuteInputAsync(IDocument input, IExecutionContext context)
         {
+            ArgumentNullException.ThrowIfNull(input);
+            ArgumentNullException.ThrowIfNull(context);
+
             NormalizedPath sidecarPath = await _sidecarPath.GetValueAsync(input, context);
             if (!sidecarPath.IsNull)
             {

--- a/src/core/Statiq.Core/Modules/Control/TakeDocuments.cs
+++ b/src/core/Statiq.Core/Modules/Control/TakeDocuments.cs
@@ -1,4 +1,5 @@
-﻿using System.Collections.Generic;
+﻿using System;
+using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
 using Statiq.Common;
@@ -22,6 +23,6 @@ namespace Statiq.Core
             _x = x;
         }
 
-        protected override IEnumerable<IDocument> ExecuteContext(IExecutionContext context) => context.Inputs.Take(_x);
+        protected override IEnumerable<IDocument> ExecuteContext(IExecutionContext context) => (context ?? throw new ArgumentNullException(nameof(context))).Inputs.Take(_x);
     }
 }

--- a/src/core/Statiq.Core/Modules/Control/ThrowException.cs
+++ b/src/core/Statiq.Core/Modules/Control/ThrowException.cs
@@ -8,7 +8,9 @@ namespace Statiq.Core
     /// Throws an exception.
     /// </summary>
     /// <category name="Control" />
+#pragma warning disable CA1711 // Identifiers should not have incorrect suffix
     public class ThrowException : SyncConfigModule<Exception>
+#pragma warning restore CA1711 // Identifiers should not have incorrect suffix
     {
         /// <summary>
         /// Throws the specified exception.
@@ -34,6 +36,9 @@ namespace Statiq.Core
             {
                 throw value;
             }
+
+            ArgumentNullException.ThrowIfNull(context);
+
             return input is null ? context.Inputs : input.Yield();
         }
     }

--- a/src/core/Statiq.Core/Modules/Extensibility/EvaluateScript.cs
+++ b/src/core/Statiq.Core/Modules/Extensibility/EvaluateScript.cs
@@ -1,4 +1,5 @@
-﻿using System.Collections.Generic;
+﻿using System;
+using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using System.Threading.Tasks;
@@ -14,6 +15,8 @@ namespace Statiq.Core
     {
         protected override async Task<IEnumerable<IDocument>> ExecuteInputAsync(IDocument input, IExecutionContext context)
         {
+            ArgumentNullException.ThrowIfNull(context);
+
             object value = await context.ScriptHelper.EvaluateAsync(await input.GetContentStringAsync(), input);
             return await context.CloneOrCreateDocumentsAsync(input, input.Yield(), value ?? new NullContent());
         }

--- a/src/core/Statiq.Core/Modules/Extensibility/ExecuteConfig.cs
+++ b/src/core/Statiq.Core/Modules/Extensibility/ExecuteConfig.cs
@@ -48,6 +48,8 @@ namespace Statiq.Core
 
         protected override Task<IEnumerable<IDocument>> ExecuteConfigAsync(IDocument input, IExecutionContext context, object value)
         {
+            ArgumentNullException.ThrowIfNull(context);
+
             IEnumerable<IDocument> inputs = context.Inputs;
             if (input is object)
             {

--- a/src/core/Statiq.Core/Modules/Extensibility/LogMessage.cs
+++ b/src/core/Statiq.Core/Modules/Extensibility/LogMessage.cs
@@ -1,4 +1,5 @@
-﻿using System.Collections.Generic;
+﻿using System;
+using System.Collections.Generic;
 using System.Diagnostics;
 using System.Threading.Tasks;
 using Microsoft.Extensions.Logging;
@@ -41,6 +42,8 @@ namespace Statiq.Core
 
         protected override IEnumerable<IDocument> ExecuteConfig(IDocument input, IExecutionContext context, string value)
         {
+            ArgumentNullException.ThrowIfNull(context);
+
             context.Log(_logLevel, value);
             return input is null ? context.Inputs : input.Yield();
         }

--- a/src/core/Statiq.Core/Modules/Extensibility/StartProcess.cs
+++ b/src/core/Statiq.Core/Modules/Extensibility/StartProcess.cs
@@ -302,6 +302,8 @@ namespace Statiq.Core
 
         protected override IEnumerable<IDocument> ExecuteConfig(IDocument input, IExecutionContext context, IMetadata values)
         {
+            ArgumentNullException.ThrowIfNull(context);
+
             // Only execute once if requested
             if (_onlyOnce && _executed)
             {

--- a/src/core/Statiq.Core/Modules/IO/CopyFiles.cs
+++ b/src/core/Statiq.Core/Modules/IO/CopyFiles.cs
@@ -97,6 +97,8 @@ namespace Statiq.Core
         {
             if (value is object)
             {
+                ArgumentNullException.ThrowIfNull(context);
+
                 // Use a semaphore to limit the write operations so we don't try to do a bunch of writes at once
                 SemaphoreSlim semaphore = new SemaphoreSlim(20, 20);
 

--- a/src/core/Statiq.Core/Modules/IO/MirrorResources.cs
+++ b/src/core/Statiq.Core/Modules/IO/MirrorResources.cs
@@ -67,7 +67,10 @@ namespace Statiq.Core
 
         protected override async Task<IEnumerable<Common.IDocument>> ExecuteContextAsync(IExecutionContext context)
         {
+            ArgumentNullException.ThrowIfNull(context);
+
 #pragma warning disable RCS1163 // Unused parameter.
+
             // Handle invalid HTTPS certificates and allow alternate security protocols (see http://stackoverflow.com/a/5670954/807064)
             ServicePointManager.ServerCertificateValidationCallback = (s, cert, chain, ssl) => true;
 #pragma warning restore RCS1163 // Unused parameter.

--- a/src/core/Statiq.Core/Modules/IO/ReadApplicationInput.cs
+++ b/src/core/Statiq.Core/Modules/IO/ReadApplicationInput.cs
@@ -18,6 +18,8 @@ namespace Statiq.Core
         /// <inheritdoc />
         protected override IEnumerable<IDocument> ExecuteContext(IExecutionContext context)
         {
+            ArgumentNullException.ThrowIfNull(context);
+
             // If ApplicationInput is empty, return nothing
             if (string.IsNullOrWhiteSpace(context.ApplicationState.Input))
             {

--- a/src/core/Statiq.Core/Modules/IO/ReadFiles.cs
+++ b/src/core/Statiq.Core/Modules/IO/ReadFiles.cs
@@ -103,6 +103,8 @@ namespace Statiq.Core
 
         protected override async Task<IEnumerable<IDocument>> ExecuteConfigAsync(IDocument input, IExecutionContext context, IEnumerable<string> value)
         {
+            ArgumentNullException.ThrowIfNull(context);
+
             IEnumerable<IFile> files = context.FileSystem.GetInputFiles(value);
             files = await files.ParallelWhereAsync(async file => _predicate is null || await _predicate(file));
             return files.AsParallel()

--- a/src/core/Statiq.Core/Modules/IO/ReadWeb.cs
+++ b/src/core/Statiq.Core/Modules/IO/ReadWeb.cs
@@ -7,6 +7,7 @@ using System.Net;
 using System.Net.Http;
 using System.Threading.Tasks;
 using Microsoft.Extensions.Logging;
+using Polly;
 using Statiq.Common;
 
 namespace Statiq.Core
@@ -53,6 +54,8 @@ namespace Statiq.Core
         /// <returns>The current module instance.</returns>
         public ReadWeb WithUris(params string[] uris)
         {
+            ArgumentNullException.ThrowIfNull(uris);
+
             foreach (string uri in uris)
             {
                 _requests.Add(new WebRequest(uri));

--- a/src/core/Statiq.Core/Modules/IO/SetDestination.cs
+++ b/src/core/Statiq.Core/Modules/IO/SetDestination.cs
@@ -2,6 +2,7 @@
 using System.Collections.Generic;
 using System.Threading.Tasks;
 using Microsoft.Extensions.Logging;
+using Polly;
 using Statiq.Common;
 
 namespace Statiq.Core
@@ -124,6 +125,8 @@ namespace Statiq.Core
 
         public static NormalizedPath GetCurrentDestinationFromMetadata(IDocument doc)
         {
+            ArgumentNullException.ThrowIfNull(doc);
+
             NormalizedPath path = doc.GetPath(Keys.DestinationPath);
             if (!path.IsNull)
             {
@@ -147,6 +150,8 @@ namespace Statiq.Core
             IExecutionContext context,
             NormalizedPath value)
         {
+            ArgumentNullException.ThrowIfNull(input);
+
             if (value.IsNull)
             {
                 return Task.FromResult(input.Yield());

--- a/src/core/Statiq.Core/Modules/IO/WriteFiles.cs
+++ b/src/core/Statiq.Core/Modules/IO/WriteFiles.cs
@@ -70,6 +70,8 @@ namespace Statiq.Core
         /// <inheritdoc />
         protected override async Task<IEnumerable<IDocument>> ExecuteContextAsync(IExecutionContext context)
         {
+            ArgumentNullException.ThrowIfNull(context);
+
             // Use a semaphore to limit the write operations so we don't try to do a bunch of writes at once
             SemaphoreSlim semaphore = new SemaphoreSlim(20, 20);
 

--- a/src/core/Statiq.Core/Modules/Metadata/AddDocumentsToMetadata.cs
+++ b/src/core/Statiq.Core/Modules/Metadata/AddDocumentsToMetadata.cs
@@ -45,12 +45,16 @@ namespace Statiq.Core
 
         protected override IEnumerable<IDocument> ExecuteChildren(
             IExecutionContext context,
-            ImmutableArray<IDocument> childOutputs) =>
-            childOutputs.Length == 0
+            ImmutableArray<IDocument> childOutputs)
+        {
+            ArgumentNullException.ThrowIfNull(context);
+
+            return childOutputs.Length == 0
                 ? context.Inputs
                 : context.Inputs.Select(input => input.Clone(new MetadataItems
                 {
                     { _key, childOutputs.Length == 1 ? (object)childOutputs[0] : childOutputs }
                 }));
+        }
     }
 }

--- a/src/core/Statiq.Core/Modules/Metadata/AddIndexes.cs
+++ b/src/core/Statiq.Core/Modules/Metadata/AddIndexes.cs
@@ -1,4 +1,5 @@
-﻿using System.Collections.Generic;
+﻿using System;
+using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
 using Statiq.Common;
@@ -13,7 +14,12 @@ namespace Statiq.Core
     public class AddIndexes : Module
     {
         /// <inheritdoc />
-        protected override Task<IEnumerable<IDocument>> ExecuteContextAsync(IExecutionContext context) =>
-            Task.FromResult(context.Inputs.Select((x, i) => x.Clone(new MetadataItems { { Keys.Index, i + 1 } })));
+        protected override Task<IEnumerable<IDocument>> ExecuteContextAsync(IExecutionContext context)
+        {
+            ArgumentNullException.ThrowIfNull(context);
+
+            return Task.FromResult(
+                context.Inputs.Select((x, i) => x.Clone(new MetadataItems { { Keys.Index, i + 1 } })));
+        }
     }
 }

--- a/src/core/Statiq.Core/Modules/Metadata/AddTitle.cs
+++ b/src/core/Statiq.Core/Modules/Metadata/AddTitle.cs
@@ -66,6 +66,8 @@ namespace Statiq.Core
 
         protected override async Task<IEnumerable<IDocument>> ExecuteInputAsync(IDocument input, IExecutionContext context)
         {
+            ArgumentNullException.ThrowIfNull(input);
+
             // Check if there's already a title set
             if (_keepExisting && input.ContainsKey(_key))
             {

--- a/src/core/Statiq.Core/Modules/Metadata/CopyMetadata.cs
+++ b/src/core/Statiq.Core/Modules/Metadata/CopyMetadata.cs
@@ -54,6 +54,8 @@ namespace Statiq.Core
 
         protected override Task<IEnumerable<IDocument>> ExecuteInputAsync(IDocument input, IExecutionContext context)
         {
+            ArgumentNullException.ThrowIfNull(input);
+
             if (input.TryGetValue(_fromKey, out object existingValue))
             {
                 if (_format is object)

--- a/src/core/Statiq.Core/Modules/Metadata/CreateTree.cs
+++ b/src/core/Statiq.Core/Modules/Metadata/CreateTree.cs
@@ -171,6 +171,8 @@ namespace Statiq.Core
         /// <inheritdoc />
         protected override async Task<IEnumerable<IDocument>> ExecuteContextAsync(IExecutionContext context)
         {
+            ArgumentNullException.ThrowIfNull(context);
+
             // Create a dictionary of tree nodes
             TreeNodeEqualityComparer treeNodeEqualityComparer = new TreeNodeEqualityComparer();
             Dictionary<string[], TreeNode> nodesDictionary = await context.Inputs

--- a/src/core/Statiq.Core/Modules/Metadata/FlattenTree.cs
+++ b/src/core/Statiq.Core/Modules/Metadata/FlattenTree.cs
@@ -84,6 +84,6 @@ namespace Statiq.Core
         }
 
         protected override IEnumerable<IDocument> ExecuteContext(IExecutionContext context) =>
-            context.Inputs.Flatten(_treePlaceholderKey, _childrenKey);
+            (context ?? throw new ArgumentNullException(nameof(context))).Inputs.Flatten(_treePlaceholderKey, _childrenKey);
     }
 }

--- a/src/core/Statiq.Core/Modules/Metadata/GenerateExcerpt.cs
+++ b/src/core/Statiq.Core/Modules/Metadata/GenerateExcerpt.cs
@@ -116,6 +116,8 @@ namespace Statiq.Core
 
         protected override async Task<IEnumerable<Common.IDocument>> ExecuteInputAsync(Common.IDocument input, IExecutionContext context)
         {
+            ArgumentNullException.ThrowIfNull(input);
+
             if (string.IsNullOrWhiteSpace(_metadataKey) || (_keepExisting && input.ContainsKey(_metadataKey)))
             {
                 return input.Yield();

--- a/src/core/Statiq.Core/Modules/Metadata/MergeMetadata.cs
+++ b/src/core/Statiq.Core/Modules/Metadata/MergeMetadata.cs
@@ -70,19 +70,29 @@ namespace Statiq.Core
 
         protected override IEnumerable<IDocument> ExecuteChildren(
             IExecutionContext context,
-            ImmutableArray<IDocument> childOutputs) =>
-            _reverse
+            ImmutableArray<IDocument> childOutputs)
+        {
+            ArgumentNullException.ThrowIfNull(context);
+
+            return _reverse
                 ? childOutputs.SelectMany(childOutput =>
                 {
                     IMetadata childOutputWithoutSettings = childOutput.WithoutSettings();
                     return context.Inputs.Select(input =>
-                        childOutput.Clone(_keepExisting ? input.WithoutSettings().GetRawEnumerable().Where(x => !childOutputWithoutSettings.ContainsKey(x.Key)) : input));
+                        childOutput.Clone(_keepExisting
+                            ? input.WithoutSettings().GetRawEnumerable()
+                                .Where(x => !childOutputWithoutSettings.ContainsKey(x.Key))
+                            : input));
                 })
                 : context.Inputs.SelectMany(input =>
                 {
                     IMetadata inputWithoutSettings = input.WithoutSettings();
                     return childOutputs.Select(result =>
-                        input.Clone(_keepExisting ? result.WithoutSettings().GetRawEnumerable().Where(x => !inputWithoutSettings.ContainsKey(x.Key)) : result));
+                        input.Clone(_keepExisting
+                            ? result.WithoutSettings().GetRawEnumerable()
+                                .Where(x => !inputWithoutSettings.ContainsKey(x.Key))
+                            : result));
                 });
+        }
     }
 }

--- a/src/core/Statiq.Core/Modules/Metadata/OptimizeFileName.cs
+++ b/src/core/Statiq.Core/Modules/Metadata/OptimizeFileName.cs
@@ -103,6 +103,8 @@ namespace Statiq.Core
 
         protected override IEnumerable<IDocument> ExecuteConfig(IDocument input, IExecutionContext context, IMetadata values)
         {
+            ArgumentNullException.ThrowIfNull(input);
+
             // Get file name
             NormalizedPath path = values.GetPath(Path);
             if (path.IsNull)

--- a/src/core/Statiq.Core/Modules/Metadata/ParseJson.cs
+++ b/src/core/Statiq.Core/Modules/Metadata/ParseJson.cs
@@ -44,6 +44,8 @@ namespace Statiq.Core
 
         protected override async Task<IEnumerable<IDocument>> ExecuteInputAsync(IDocument input, IExecutionContext context)
         {
+            ArgumentNullException.ThrowIfNull(context);
+
             MetadataDictionary metadata;
             using (Stream contentStream = input.GetContentStream())
             {

--- a/src/core/Statiq.Core/Modules/Metadata/ReadApi.cs
+++ b/src/core/Statiq.Core/Modules/Metadata/ReadApi.cs
@@ -347,6 +347,8 @@ namespace Statiq.Core
             IExecutionContext context,
             TClient client)
         {
+            ArgumentNullException.ThrowIfNull(request);
+
             try
             {
                 return await request(input, context, client);

--- a/src/core/Statiq.Core/Modules/Metadata/ReadSql.cs
+++ b/src/core/Statiq.Core/Modules/Metadata/ReadSql.cs
@@ -55,7 +55,9 @@ namespace Statiq.Core
         }
 
         /// <inheritdoc />
+#pragma warning disable CA1725 // Parameter names should match base declaration
         protected override IDictionary<string, object> GetDictionary(DataRow row) =>
-            row.Table.Columns.Cast<DataColumn>().ToDictionary(col => col.ColumnName, col => row[col]);
+            (row ?? throw new ArgumentNullException(nameof(row))).Table.Columns.Cast<DataColumn>().ToDictionary(col => col.ColumnName, col => row[col]);
+#pragma warning restore CA1725 // Parameter names should match base declaration
     }
 }

--- a/src/core/Statiq.Core/Modules/Metadata/ReadXml.cs
+++ b/src/core/Statiq.Core/Modules/Metadata/ReadXml.cs
@@ -90,6 +90,8 @@ namespace Statiq.Core
             // Get XML from the input documents?
             if (_data is null)
             {
+                ArgumentNullException.ThrowIfNull(context);
+
                 return context.Inputs.AsParallel().SelectMany(input =>
                 {
                     XmlDocument inputDoc = new XmlDocument();

--- a/src/core/Statiq.Core/Modules/Metadata/RemoveTreePlaceholders.cs
+++ b/src/core/Statiq.Core/Modules/Metadata/RemoveTreePlaceholders.cs
@@ -32,6 +32,6 @@ namespace Statiq.Core
         }
 
         protected override IEnumerable<IDocument> ExecuteContext(IExecutionContext context) =>
-            context.Inputs.RemoveTreePlaceholders(_treePlaceholderKey);
+            (context ?? throw new ArgumentNullException(nameof(context))).Inputs.RemoveTreePlaceholders(_treePlaceholderKey);
     }
 }

--- a/src/core/Statiq.Core/Modules/Metadata/SetMetadata.cs
+++ b/src/core/Statiq.Core/Modules/Metadata/SetMetadata.cs
@@ -56,10 +56,14 @@ namespace Statiq.Core
             return this;
         }
 
-        protected override Task<IEnumerable<IDocument>> ExecuteConfigAsync(IDocument input, IExecutionContext context, object value) =>
-            Task.FromResult(
+        protected override Task<IEnumerable<IDocument>> ExecuteConfigAsync(IDocument input, IExecutionContext context, object value)
+        {
+            ArgumentNullException.ThrowIfNull(input);
+
+            return Task.FromResult(
                 (_onlyIfNonExisting && input.ContainsKey(_key)) || (_ignoreNull && value is null)
                     ? input.Yield()
                     : input.Clone(new MetadataItems { { _key, value } }).Yield());
+        }
     }
 }

--- a/src/core/Statiq.Core/Modules/Metadata/ValidateMetadata{T}.cs
+++ b/src/core/Statiq.Core/Modules/Metadata/ValidateMetadata{T}.cs
@@ -85,6 +85,8 @@ namespace Statiq.Core
         /// <inheritdoc />
         protected override Task<IEnumerable<IDocument>> ExecuteContextAsync(IExecutionContext context)
         {
+            ArgumentNullException.ThrowIfNull(context);
+
             Parallel.ForEach(context.Inputs, input =>
             {
                 // Check if the key exists

--- a/src/core/Statiq.Core/Modules/Templates/TransformXslt.cs
+++ b/src/core/Statiq.Core/Modules/Templates/TransformXslt.cs
@@ -1,4 +1,5 @@
-﻿using System.Collections.Generic;
+﻿using System;
+using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using System.Threading.Tasks;
@@ -45,6 +46,8 @@ namespace Statiq.Core
 
         protected override async Task<IEnumerable<IDocument>> ExecuteInputAsync(IDocument input, IExecutionContext context)
         {
+            ArgumentNullException.ThrowIfNull(context);
+
             XslCompiledTransform xslt = new XslCompiledTransform();
 
             if (_xsltPath is object)

--- a/src/core/Statiq.Core/Scripting/ScriptCompilationException.cs
+++ b/src/core/Statiq.Core/Scripting/ScriptCompilationException.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using Polly;
 
 namespace Statiq.Core
 {
@@ -9,6 +10,8 @@ namespace Statiq.Core
 
         public ScriptCompilationException(List<string> errorMessages)
         {
+            ArgumentNullException.ThrowIfNull(errorMessages);
+
             ErrorMessages = errorMessages.AsReadOnly();
         }
     }

--- a/src/core/Statiq.Core/Scripting/ScriptHelper.cs
+++ b/src/core/Statiq.Core/Scripting/ScriptHelper.cs
@@ -12,6 +12,7 @@ using Microsoft.CodeAnalysis.Emit;
 using Microsoft.CodeAnalysis.Text;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
+using Polly;
 using Statiq.Common;
 
 namespace Statiq.Core
@@ -151,6 +152,8 @@ namespace Statiq.Core
 
         public static void LogAndEnsureCompilationSuccess(EmitResult result, ILogger logger, string name = null)
         {
+            ArgumentNullException.ThrowIfNull(result);
+
             // Log warnings
             List<string> warningMessages = result.Diagnostics
                 .Where(x => x.Severity == DiagnosticSeverity.Warning)

--- a/src/core/Statiq.Core/Shortcodes/Content/EvalShortcode.cs
+++ b/src/core/Statiq.Core/Shortcodes/Content/EvalShortcode.cs
@@ -1,4 +1,5 @@
-﻿using System.Collections.Generic;
+﻿using System;
+using System.Collections.Generic;
 using System.Threading.Tasks;
 using Statiq.Common;
 
@@ -17,6 +18,8 @@ namespace Statiq.Core
     {
         public override async Task<ShortcodeResult> ExecuteAsync(KeyValuePair<string, string>[] args, string content, IDocument document, IExecutionContext context)
         {
+            ArgumentNullException.ThrowIfNull(context);
+
             object value = await context.ScriptHelper.EvaluateAsync(content, document);
             return value.ToString();
         }

--- a/src/core/Statiq.Core/Shortcodes/IO/IncludeShortcode.cs
+++ b/src/core/Statiq.Core/Shortcodes/IO/IncludeShortcode.cs
@@ -45,6 +45,8 @@ namespace Statiq.Core
         /// <inheritdoc />
         public override async Task<ShortcodeResult> ExecuteAsync(KeyValuePair<string, string>[] args, string content, IDocument document, IExecutionContext context)
         {
+            ArgumentNullException.ThrowIfNull(context);
+
             // See if this is a web include
             string included = args.SingleValue();
             if (included.StartsWith(Uri.UriSchemeHttp + "://") || included.StartsWith(Uri.UriSchemeHttps + "://"))
@@ -69,6 +71,8 @@ namespace Statiq.Core
             NormalizedPath includedPath = new NormalizedPath(included);
             if (_sourcePath.IsNull)
             {
+                ArgumentNullException.ThrowIfNull(document);
+
                 // Cache the source path for this shortcode instance since it'll be the same for all future shortcodes
                 _sourcePath = document.GetPath("IncludeShortcodeSource", document.Source);
             }

--- a/src/core/Statiq.Core/Statiq.Core.csproj
+++ b/src/core/Statiq.Core/Statiq.Core.csproj
@@ -7,13 +7,13 @@
     <PackageReference Include="JavaScriptEngineSwitcher.Core" Version="3.21.0" />
     <PackageReference Include="JavaScriptEngineSwitcher.Jint" Version="3.21.2" />
     <PackageReference Include="JSPool" Version="2.0.1" />
-    <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="4.1.0" />
-    <PackageReference Include="Microsoft.Extensions.Logging" Version="3.1.18" />
-    <PackageReference Include="Microsoft.IO.RecyclableMemoryStream" Version="1.2.2" />
+    <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="4.8.0" />
+    <PackageReference Include="Microsoft.Extensions.Logging" Version="8.0.0" />
+    <PackageReference Include="Microsoft.IO.RecyclableMemoryStream" Version="3.0.0" />
     <PackageReference Include="Polly" Version="7.1.1" />
     <PackageReference Include="SemanticVersioning" Version="1.2.2" />
-    <PackageReference Include="System.Collections.Immutable" Version="5.0.0" />
-    <PackageReference Include="Microsoft.Data.SqlClient" Version="5.0.1" />
+    <PackageReference Include="System.Collections.Immutable" Version="8.0.0" />
+    <PackageReference Include="Microsoft.Data.SqlClient" Version="5.1.2" />
     <PackageReference Include="System.Linq.Async" Version="6.0.1" />
   </ItemGroup>
   <ItemGroup>

--- a/src/core/Statiq.Core/Statiq.Core.csproj
+++ b/src/core/Statiq.Core/Statiq.Core.csproj
@@ -7,7 +7,7 @@
     <PackageReference Include="JavaScriptEngineSwitcher.Core" Version="3.21.0" />
     <PackageReference Include="JavaScriptEngineSwitcher.Jint" Version="3.21.2" />
     <PackageReference Include="JSPool" Version="2.0.1" />
-    <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="4.8.0" />
+    <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="4.4.0" />
     <PackageReference Include="Microsoft.Extensions.Logging" Version="8.0.0" />
     <PackageReference Include="Microsoft.IO.RecyclableMemoryStream" Version="3.0.0" />
     <PackageReference Include="Polly" Version="7.1.1" />

--- a/src/core/Statiq.Core/Statiq.Core.csproj
+++ b/src/core/Statiq.Core/Statiq.Core.csproj
@@ -11,7 +11,7 @@
     <PackageReference Include="Microsoft.Extensions.Logging" Version="8.0.0" />
     <PackageReference Include="Microsoft.IO.RecyclableMemoryStream" Version="3.0.0" />
     <PackageReference Include="Polly" Version="7.1.1" />
-    <PackageReference Include="SemanticVersioning" Version="1.2.2" />
+    <PackageReference Include="SemanticVersioning" Version="2.0.2" />
     <PackageReference Include="System.Collections.Immutable" Version="8.0.0" />
     <PackageReference Include="Microsoft.Data.SqlClient" Version="5.1.2" />
     <PackageReference Include="System.Linq.Async" Version="6.0.1" />

--- a/src/core/Statiq.Core/Util/ArgumentSplitter.cs
+++ b/src/core/Statiq.Core/Util/ArgumentSplitter.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Linq;
+using Polly;
 
 namespace Statiq.Core
 {
@@ -19,6 +20,8 @@ namespace Statiq.Core
         /// <returns>Each quoted argument as delimited in the original string by spaces.</returns>
         public static IEnumerable<string> Split(string arguments)
         {
+            ArgumentNullException.ThrowIfNull(arguments);
+
             bool inQuotes = false;
 
             return arguments

--- a/src/core/Statiq.Core/Util/SynchronizationContextRemover.cs
+++ b/src/core/Statiq.Core/Util/SynchronizationContextRemover.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Runtime.CompilerServices;
 using System.Threading;
+using Polly;
 
 namespace Statiq.Core
 {
@@ -15,6 +16,8 @@ namespace Statiq.Core
 
         public void OnCompleted(Action continuation)
         {
+            ArgumentNullException.ThrowIfNull(continuation);
+
             SynchronizationContext previousContext = SynchronizationContext.Current;
             try
             {

--- a/src/core/Statiq.Testing/Analyzers/TestAnalyzerContext.cs
+++ b/src/core/Statiq.Testing/Analyzers/TestAnalyzerContext.cs
@@ -23,7 +23,9 @@ namespace Statiq.Testing
         {
         }
 
+#pragma warning disable CA1721
         public LogLevel LogLevel { get; set; } = LogLevel.Warning;
+#pragma warning restore CA1721
 
         public ConcurrentBag<TestAnalyzerResult> AnalyzerResults { get; } = new ConcurrentBag<TestAnalyzerResult>();
 

--- a/src/core/Statiq.Testing/Statiq.Testing.csproj
+++ b/src/core/Statiq.Testing/Statiq.Testing.csproj
@@ -4,14 +4,14 @@
     <PackageTags>Statiq Static StaticContent StaticSite Blog BlogEngine</PackageTags>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="3.1.18" />
-    <PackageReference Include="Microsoft.Extensions.Logging" Version="3.1.18" />
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="8.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Logging" Version="8.0.0" />
     <PackageReference Include="NUnit" Version="3.12.0" />
     <PackageReference Include="Shouldly" Version="4.0.3">
       <!-- See https://github.com/shouldly/shouldly/issues/795 -->
       <ExcludeAssets>build</ExcludeAssets>
     </PackageReference>
-    <PackageReference Include="System.Collections.Immutable" Version="5.0.0" />
+    <PackageReference Include="System.Collections.Immutable" Version="8.0.0" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\Statiq.Common\Statiq.Common.csproj" />

--- a/src/core/Statiq.Testing/Statiq.Testing.csproj
+++ b/src/core/Statiq.Testing/Statiq.Testing.csproj
@@ -7,7 +7,7 @@
     <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="8.0.0" />
     <PackageReference Include="Microsoft.Extensions.Logging" Version="8.0.0" />
     <PackageReference Include="NUnit" Version="3.12.0" />
-    <PackageReference Include="Shouldly" Version="4.0.3">
+    <PackageReference Include="Shouldly" Version="4.2.1">
       <!-- See https://github.com/shouldly/shouldly/issues/795 -->
       <ExcludeAssets>build</ExcludeAssets>
     </PackageReference>

--- a/src/extensions/Statiq.CodeAnalysis/AnalyzeCSharp.cs
+++ b/src/extensions/Statiq.CodeAnalysis/AnalyzeCSharp.cs
@@ -455,6 +455,8 @@ namespace Statiq.CodeAnalysis
         /// <inheritdoc />
         protected override async Task<IEnumerable<IDocument>> ExecuteContextAsync(IExecutionContext context)
         {
+            ArgumentNullException.ThrowIfNull(context);
+
             // Create the compilation (have to supply an XmlReferenceResolver to handle include XML doc comments)
             MetadataReference mscorlib = MetadataReference.CreateFromFile(typeof(object).Assembly.Location);
             CSharpCompilation compilation = CSharpCompilation

--- a/src/extensions/Statiq.CodeAnalysis/ISymbolExtensions.cs
+++ b/src/extensions/Statiq.CodeAnalysis/ISymbolExtensions.cs
@@ -95,7 +95,7 @@ namespace Statiq.CodeAnalysis
                 // Add .dll to assembly names
                 return symbol.Name + ".dll";
             }
-            if (symbol.Kind == SymbolKind.Namespace)
+            if (symbol?.Kind == SymbolKind.Namespace)
             {
                 // Use "global" for the global namespace display name since it's a reserved keyword and it's used to refer to the global namespace in code
                 return symbol.ContainingNamespace is null ? "global" : GetQualifiedName(symbol);

--- a/src/extensions/Statiq.CodeAnalysis/ReadProject.cs
+++ b/src/extensions/Statiq.CodeAnalysis/ReadProject.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Collections.Generic;
 using System.IO;
 using Buildalyzer;
@@ -43,6 +44,9 @@ namespace Statiq.CodeAnalysis
         /// <inheritdoc />
         protected override IEnumerable<Project> GetProjects(IExecutionContext context, IFile file)
         {
+            ArgumentNullException.ThrowIfNull(context);
+            ArgumentNullException.ThrowIfNull(file);
+
             StringWriter log = new StringWriter();
             AnalyzerManager manager = new AnalyzerManager(new AnalyzerManagerOptions
             {

--- a/src/extensions/Statiq.CodeAnalysis/ReadSolution.cs
+++ b/src/extensions/Statiq.CodeAnalysis/ReadSolution.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
@@ -44,6 +45,8 @@ namespace Statiq.CodeAnalysis
         /// <inheritdoc />
         protected override IEnumerable<Project> GetProjects(IExecutionContext context, IFile file)
         {
+            ArgumentNullException.ThrowIfNull(file);
+
             StringWriter log = new StringWriter();
             AnalyzerManager manager = new AnalyzerManager(file.Path.Parent.FullPath, new AnalyzerManagerOptions
             {

--- a/src/extensions/Statiq.CodeAnalysis/ReadWorkspace.cs
+++ b/src/extensions/Statiq.CodeAnalysis/ReadWorkspace.cs
@@ -3,7 +3,6 @@ using System.Collections.Generic;
 using System.Diagnostics;
 using System.IO;
 using System.Linq;
-using System.Threading.Tasks;
 using Buildalyzer;
 using Microsoft.CodeAnalysis;
 using Microsoft.Extensions.Logging;
@@ -74,6 +73,10 @@ namespace Statiq.CodeAnalysis
 
         protected internal static IAnalyzerResult CompileProject(IExecutionContext context, IProjectAnalyzer analyzer, StringWriter log)
         {
+            ArgumentNullException.ThrowIfNull(context);
+            ArgumentNullException.ThrowIfNull(analyzer);
+            ArgumentNullException.ThrowIfNull(log);
+
             log.GetStringBuilder().Clear();
             context.LogDebug($"Building project {analyzer.ProjectFile.Path}");
             Stopwatch sw = new Stopwatch();
@@ -92,6 +95,8 @@ namespace Statiq.CodeAnalysis
 
         protected override IEnumerable<IDocument> ExecuteConfig(IDocument input, IExecutionContext context, NormalizedPath value)
         {
+            ArgumentNullException.ThrowIfNull(context);
+
             if (!value.IsNull)
             {
                 IFile projectFile = context.FileSystem.GetInputFile(value);

--- a/src/extensions/Statiq.CodeAnalysis/Statiq.CodeAnalysis.csproj
+++ b/src/extensions/Statiq.CodeAnalysis/Statiq.CodeAnalysis.csproj
@@ -4,7 +4,7 @@
     <PackageTags>Statiq Static StaticContent StaticSite Blog BlogEngine CodeAnalysis Roslyn XmlDocComments DocComments</PackageTags>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Buildalyzer.Workspaces" Version="4.1.2" />
+    <PackageReference Include="Buildalyzer.Workspaces" Version="6.0.3" />
     <PackageReference Include="System.Linq.Async" Version="6.0.1" />
   </ItemGroup>
   <ItemGroup>

--- a/src/extensions/Statiq.Feeds/GenerateFeeds.cs
+++ b/src/extensions/Statiq.Feeds/GenerateFeeds.cs
@@ -519,7 +519,7 @@ namespace Statiq.Feeds
             {
                 IHtmlDocument dom = parser.ParseDocument(string.Empty);
                 INodeList nodes = parser.ParseFragment(value, dom.Body);
-                IEnumerable<IElement> elements = nodes.SelectMany(x => x.Descendents<IElement>().Where(y => y.HasAttribute("href") || y.HasAttribute("src")));
+                IEnumerable<IElement> elements = nodes.SelectMany(x => x.Descendants<IElement>().Where(y => y.HasAttribute("href") || y.HasAttribute("src")));
                 bool replaced = false;
                 foreach (IElement element in elements)
                 {

--- a/src/extensions/Statiq.Feeds/Syndication/Extensions/ExtensibleBase.cs
+++ b/src/extensions/Statiq.Feeds/Syndication/Extensions/ExtensibleBase.cs
@@ -118,7 +118,9 @@ namespace Statiq.Feeds.Syndication.Extensions
         }
 
         protected static string ConvertToString(Uri uri) =>
+#pragma warning disable SYSLIB0013
             uri is null ? null : Uri.EscapeUriString(uri.ToString());
+#pragma warning restore SYSLIB0013
 
         protected static Uri ConvertToUri(string value)
         {

--- a/src/extensions/Statiq.Feeds/Syndication/Rss/RssItem.cs
+++ b/src/extensions/Statiq.Feeds/Syndication/Rss/RssItem.cs
@@ -223,7 +223,9 @@ namespace Statiq.Feeds.Syndication.Rss
         }
 
         [XmlElement("guid")]
+#pragma warning disable CA1720
         public RssGuid Guid
+#pragma warning restore CA1720
         {
             get
             {

--- a/src/extensions/Statiq.Markdown/Statiq.Markdown.csproj
+++ b/src/extensions/Statiq.Markdown/Statiq.Markdown.csproj
@@ -4,7 +4,7 @@
     <PackageTags>Statiq Static StaticContent StaticSite Blog BlogEngine Markdown</PackageTags>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Markdig" Version="0.31.0" />
+    <PackageReference Include="Markdig" Version="0.34.0" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\..\core\Statiq.Common\Statiq.Common.csproj" />

--- a/src/extensions/Statiq.Razor/Statiq.Razor.csproj
+++ b/src/extensions/Statiq.Razor/Statiq.Razor.csproj
@@ -7,13 +7,13 @@
     <FrameworkReference Include="Microsoft.AspNetCore.App" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="Microsoft.AspNetCore.Razor.Language" Version="3.1.15" />
-    <PackageReference Include="Microsoft.AspNetCore.Mvc.Razor.RuntimeCompilation" Version="3.1.15" />
-    <PackageReference Include="Microsoft.AspNetCore.Mvc.Razor.Extensions" Version="3.1.15" />
-    <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="4.1.0" />
-    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="3.1.18" />
-    <PackageReference Include="Microsoft.Extensions.FileProviders.Composite" Version="3.1.18" />
-    <PackageReference Include="Microsoft.Extensions.FileProviders.Physical" Version="3.1.18" />
+    <PackageReference Include="Microsoft.AspNetCore.Razor.Language" Version="6.0.25" />
+    <PackageReference Include="Microsoft.AspNetCore.Mvc.Razor.RuntimeCompilation" Version="8.0.0" />
+    <PackageReference Include="Microsoft.AspNetCore.Mvc.Razor.Extensions" Version="6.0.25" />
+    <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="4.8.0" />
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="8.0.0" />
+    <PackageReference Include="Microsoft.Extensions.FileProviders.Composite" Version="8.0.0" />
+    <PackageReference Include="Microsoft.Extensions.FileProviders.Physical" Version="8.0.0" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\..\core\Statiq.Common\Statiq.Common.csproj" />

--- a/src/extensions/Statiq.Razor/Statiq.Razor.csproj
+++ b/src/extensions/Statiq.Razor/Statiq.Razor.csproj
@@ -10,7 +10,8 @@
     <PackageReference Include="Microsoft.AspNetCore.Razor.Language" Version="6.0.25" />
     <PackageReference Include="Microsoft.AspNetCore.Mvc.Razor.RuntimeCompilation" Version="8.0.0" />
     <PackageReference Include="Microsoft.AspNetCore.Mvc.Razor.Extensions" Version="6.0.25" />
-    <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="4.8.0" />
+    <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="4.4.0" />
+    <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Scripting" Version="4.4.0" />
     <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="8.0.0" />
     <PackageReference Include="Microsoft.Extensions.FileProviders.Composite" Version="8.0.0" />
     <PackageReference Include="Microsoft.Extensions.FileProviders.Physical" Version="8.0.0" />

--- a/src/extensions/Statiq.Razor/StatiqRazorProjectFileSystem.cs
+++ b/src/extensions/Statiq.Razor/StatiqRazorProjectFileSystem.cs
@@ -28,7 +28,9 @@ namespace Statiq.Razor
         }
 
         [Obsolete("Use GetItem(string path, string fileKind) instead.")]
+#pragma warning disable CS0809 // Obsolete member overrides non-obsolete member
         public override RazorProjectItem GetItem(string path)
+#pragma warning restore CS0809 // Obsolete member overrides non-obsolete member
         {
             return GetItem(path, fileKind: null);
         }

--- a/src/extensions/Statiq.Xmp/Statiq.Xmp.csproj
+++ b/src/extensions/Statiq.Xmp/Statiq.Xmp.csproj
@@ -5,7 +5,7 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="MetadataExtractor" Version="2.2.0" />
-    <PackageReference Include="SharpZipLib" Version="1.2.0" />
+    <PackageReference Include="SharpZipLib" Version="1.4.2" />
     <PackageReference Include="XmpCore" Version="6.1.10" />
   </ItemGroup>
   <ItemGroup>

--- a/src/extensions/Statiq.Yaml/Statiq.Yaml.csproj
+++ b/src/extensions/Statiq.Yaml/Statiq.Yaml.csproj
@@ -4,7 +4,7 @@
     <PackageTags>Statiq Static StaticContent StaticSite Blog BlogEngine Yaml</PackageTags>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="YamlDotNet" Version="13.0.0" />
+    <PackageReference Include="YamlDotNet" Version="13.7.1" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\..\core\Statiq.Common\Statiq.Common.csproj" />

--- a/tests/Directory.Build.props
+++ b/tests/Directory.Build.props
@@ -6,6 +6,6 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.8.0" />
-    <PackageReference Include="NUnit3TestAdapter" Version="4.2.0" />
+    <PackageReference Include="NUnit3TestAdapter" Version="4.5.0" />
   </ItemGroup>
 </Project>

--- a/tests/Directory.Build.props
+++ b/tests/Directory.Build.props
@@ -5,7 +5,7 @@
     <HasRuntimeOutput>true</HasRuntimeOutput>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.0.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.8.0" />
     <PackageReference Include="NUnit3TestAdapter" Version="4.2.0" />
   </ItemGroup>
 </Project>

--- a/tests/core/Statiq.Common.Tests/Statiq.Common.Tests.csproj
+++ b/tests/core/Statiq.Common.Tests/Statiq.Common.Tests.csproj
@@ -5,7 +5,7 @@
     <ProjectReference Include="..\..\..\src\core\Statiq.Testing\Statiq.Testing.csproj" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="3.1.18" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="8.0.0" />
   </ItemGroup>
   <ItemGroup>
     <Folder Include="Scripting\" />

--- a/tests/core/Statiq.Core.Tests/Statiq.Core.Tests.csproj
+++ b/tests/core/Statiq.Core.Tests/Statiq.Core.Tests.csproj
@@ -5,6 +5,6 @@
     <ProjectReference Include="..\..\..\src\core\Statiq.Testing\Statiq.Testing.csproj" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="3.1.18" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="8.0.0" />
   </ItemGroup>
 </Project>

--- a/tests/core/TestConsoleApp/TestConsoleApp.csproj
+++ b/tests/core/TestConsoleApp/TestConsoleApp.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
   </PropertyGroup>
 
 </Project>

--- a/tests/extensions/Statiq.CodeAnalysis.Tests/AnalyzeCSharpTypesFixture.cs
+++ b/tests/extensions/Statiq.CodeAnalysis.Tests/AnalyzeCSharpTypesFixture.cs
@@ -435,7 +435,7 @@ namespace Statiq.CodeAnalysis.Tests
                 // Then
                 results.Single(x => x["Name"].Equals("Green"))["SpecificKind"].ShouldBe("Class");
                 results.Single(x => x["Name"].Equals("Blue"))["SpecificKind"].ShouldBe("Class");
-                results.Single(x => x["Name"].Equals("Red"))["SpecificKind"].ShouldBe("Structure");
+                results.Single(x => x["Name"].Equals("Red"))["SpecificKind"].ShouldBe("Struct");
                 results.Single(x => x["Name"].Equals("Yellow"))["SpecificKind"].ShouldBe("Enum");
             }
 


### PR DESCRIPTION
Update to target .NET 8 and update other packages to newer versions (where upgrading involved minimal changes).

- Add pragmas to suppress new warnings
- Add parameter null checks (to mitigate new warnings)